### PR TITLE
fix reversed creators in level headlines

### DIFF
--- a/src/model/demonlist/demon.rs
+++ b/src/model/demonlist/demon.rs
@@ -117,12 +117,12 @@ impl Model for Demon {
         demons_pv::position,
         demons_pv::requirement,
         demons_pv::video,
-        demons_pv::verifier_id,
-        demons_pv::verifier_name,
-        demons_pv::verifier_banned,
         demons_pv::publisher_id,
         demons_pv::publisher_name,
         demons_pv::publisher_banned,
+        demons_pv::verifier_id,
+        demons_pv::verifier_name,
+        demons_pv::verifier_banned,
     );
 
     fn from() -> Self::From {


### PR DESCRIPTION
el problema?
![image](https://user-images.githubusercontent.com/25387744/66186048-136c5500-e636-11e9-93fe-b2bc84e8efb4.png)

解决方案:
..
i'd like to prefix this by saying i don't know if this is a true fix or a dark magic fix
i do know it happens somewhere from the conversion to demon_p to demon_pv, and reordering this seemed to fix it
works enough for me, i guess, but there could still be some small things i didn't catch (and also i could be going about how this happened entirely wrong)
however surprising that is to you considering the list says it did happen, viprin did _not_ verify ouroboros, and voidsquad did _not_ verify atmosphere