### PR TITLE
Fix mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Currently, this repository also does not contain any static files, or a database
 
 This has both upsides and downsides. Since you'll have to write those components yourself, it will be very complicated to run custom pointercrate copies (especially since we do not actually support such endeavours). However, there are various advantages:
 
-- No code in this repository explicitly references pointercrate. Everything from the logo in the navigation bar to the site metadata in the headers is configurable. This means I wont have to shout at you 7 times or failing to remove references to pointercrate on your website
+- No code in this repository explicitly references pointercrate. Everything from the logo in the navigation bar to the site metadata in the headers is configurable. This means I wont have to shout at you 7 times for failing to remove references to pointercrate on your website
 - Each component is as independent as possible. For instance, you could run a pointercrate copy that does not use the `pointercrate-demonlist*` libraries and it would work just fine.
 
 ## Special thanks


### PR DESCRIPTION
typo at: "shout at you 7 times OR failing to remove...", I would assume. Replaced "or" with "for". I can't word this better sorry