### PR TITLE
Add color key to the List Integration tab

### DIFF
--- a/pointercrate-demonlist-pages/src/account/list_integration.rs
+++ b/pointercrate-demonlist-pages/src/account/list_integration.rs
@@ -130,25 +130,11 @@ impl AccountPageTab for ListIntegrationTab {
                                 "Your claimed player's records"
                             }
                             p {
-                                "A list of your claimed player's records, including all under consideration and rejected records and all submissions. Use this to track the status of your submissions. Clicking on a record will pull up any public notes a list mod left on the given record. "
-                                br;
-                                "The background color of each record represents different record states. Each color means the following: "
-                                br;
-                                span style = "background-color: #E9FAE3" {
-                                    "Green = Approved"
-                                }
-                                br;
-                                span style = "background-color: #D8EFF3" {
-                                    "Blue = Under Consideration"
-                                }
-                                br;
-                                span style = "background-color: #F7F7E0" {
-                                    "Yellow = Unchecked"
-                                }
-                                br;
-                                span style = "background-color: #F8DCE4" {
-                                    "Red = Rejected"
-                                }
+                                "A list of your claimed player's records, including all under consideration and rejected records and all submissions. Use this to track the status of your submissions. Clicking on a record will pull up any public notes a list mod left on the given record. The background color of each record tells you whether the record is " 
+                                span  style = "background-color: #E9FAE3" { "Green = Approved"  } ", " 
+                                span style = "background-color: #F7F7E0" {"Yellow = Unchecked" } ", "  
+                                span style = "background-color: #F8DCE4" {  "Red = Rejected" } " or " 
+                                span style = "background-color: #D8EFF3" { "Blue = Under Consideration" } "."
                             }
                             (paginator("claims-record-pagination", "/api/v1/records/"))
                         }

--- a/pointercrate-demonlist-pages/src/account/list_integration.rs
+++ b/pointercrate-demonlist-pages/src/account/list_integration.rs
@@ -130,7 +130,7 @@ impl AccountPageTab for ListIntegrationTab {
                                 "Your claimed player's records"
                             }
                             p {
-                                "A list of your claimed player's records, including all under consideration and rejected records and all submissions. Use this to track the status of your submissions. Clicking on a record will pull up any public notes a list mod left on the given record."
+                                "A list of your claimed player's records, including all under consideration and rejected records and all submissions. Use this to track the status of your submissions. Clicking on a record will pull up any public notes a list mod left on the given record. The background color of each record represents different record states. Each folor means the following: Green = Approved, Blue = Under Consideration, Yellow = Unchecked, and Red = Rejected."
                             }
                             (paginator("claims-record-pagination", "/api/v1/records/"))
                         }

--- a/pointercrate-demonlist-pages/src/account/list_integration.rs
+++ b/pointercrate-demonlist-pages/src/account/list_integration.rs
@@ -161,7 +161,7 @@ impl AccountPageTab for ListIntegrationTab {
                             "A claim with a green background is verified, a claim with a blue background is unverified/unchecked"
                         }
                         (filtered_paginator("claim-pagination", "/api/v1/players/claims/"))
-                    }src
+                    }
                 }
             }
             div.right {

--- a/pointercrate-demonlist-pages/src/account/list_integration.rs
+++ b/pointercrate-demonlist-pages/src/account/list_integration.rs
@@ -130,7 +130,17 @@ impl AccountPageTab for ListIntegrationTab {
                                 "Your claimed player's records"
                             }
                             p {
-                                "A list of your claimed player's records, including all under consideration and rejected records and all submissions. Use this to track the status of your submissions. Clicking on a record will pull up any public notes a list mod left on the given record. The background color of each record represents different record states. Each color means the following: Green = Approved, Blue = Under Consideration, Yellow = Unchecked, and Red = Rejected."
+                                "A list of your claimed player's records, including all under consideration and rejected records and all submissions. Use this to track the status of your submissions. Clicking on a record will pull up any public notes a list mod left on the given record. "
+                                br;
+                                "The background color of each record represents different record states. Each color means the following: "
+                                br;
+                                "Green = Approved"
+                                br;
+                                "Blue = Under Consideration"
+                                br;
+                                "Yellow = Unchecked"
+                                br;
+                                "Red = Rejected"
                             }
                             (paginator("claims-record-pagination", "/api/v1/records/"))
                         }
@@ -151,7 +161,7 @@ impl AccountPageTab for ListIntegrationTab {
                             "A claim with a green background is verified, a claim with a blue background is unverified/unchecked"
                         }
                         (filtered_paginator("claim-pagination", "/api/v1/players/claims/"))
-                    }
+                    }src
                 }
             }
             div.right {

--- a/pointercrate-demonlist-pages/src/account/list_integration.rs
+++ b/pointercrate-demonlist-pages/src/account/list_integration.rs
@@ -130,7 +130,7 @@ impl AccountPageTab for ListIntegrationTab {
                                 "Your claimed player's records"
                             }
                             p {
-                                "A list of your claimed player's records, including all under consideration and rejected records and all submissions. Use this to track the status of your submissions. Clicking on a record will pull up any public notes a list mod left on the given record. The background color of each record represents different record states. Each folor means the following: Green = Approved, Blue = Under Consideration, Yellow = Unchecked, and Red = Rejected."
+                                "A list of your claimed player's records, including all under consideration and rejected records and all submissions. Use this to track the status of your submissions. Clicking on a record will pull up any public notes a list mod left on the given record. The background color of each record represents different record states. Each color means the following: Green = Approved, Blue = Under Consideration, Yellow = Unchecked, and Red = Rejected."
                             }
                             (paginator("claims-record-pagination", "/api/v1/records/"))
                         }

--- a/pointercrate-demonlist-pages/src/account/list_integration.rs
+++ b/pointercrate-demonlist-pages/src/account/list_integration.rs
@@ -134,13 +134,21 @@ impl AccountPageTab for ListIntegrationTab {
                                 br;
                                 "The background color of each record represents different record states. Each color means the following: "
                                 br;
-                                "Green = Approved"
+                                span style = "background-color: #E9FAE3" {
+                                    "Green = Approved"
+                                }
                                 br;
-                                "Blue = Under Consideration"
+                                span style = "background-color: #D8EFF3" {
+                                    "Blue = Under Consideration"
+                                }
                                 br;
-                                "Yellow = Unchecked"
+                                span style = "background-color: #F7F7E0" {
+                                    "Yellow = Unchecked"
+                                }
                                 br;
-                                "Red = Rejected"
+                                span style = "background-color: #F8DCE4" {
+                                    "Red = Rejected"
+                                }
                             }
                             (paginator("claims-record-pagination", "/api/v1/records/"))
                         }

--- a/pointercrate-demonlist-pages/src/account/list_integration.rs
+++ b/pointercrate-demonlist-pages/src/account/list_integration.rs
@@ -131,10 +131,10 @@ impl AccountPageTab for ListIntegrationTab {
                             }
                             p {
                                 "A list of your claimed player's records, including all under consideration and rejected records and all submissions. Use this to track the status of your submissions. Clicking on a record will pull up any public notes a list mod left on the given record. The background color of each record tells you whether the record is " 
-                                span  style = "background-color: #E9FAE3" { "Green = Approved"  } ", " 
-                                span style = "background-color: #F7F7E0" {"Yellow = Unchecked" } ", "  
-                                span style = "background-color: #F8DCE4" {  "Red = Rejected" } " or " 
-                                span style = "background-color: #D8EFF3" { "Blue = Under Consideration" } "."
+                                span  style = "background-color: #E9FAE3" { "Approved"  } ", " 
+                                span style = "background-color: #F7F7E0" { "Unchecked" } ", "  
+                                span style = "background-color: #F8DCE4" { "Rejected" } " or " 
+                                span style = "background-color: #D8EFF3" { "Under Consideration" } "."
                             }
                             (paginator("claims-record-pagination", "/api/v1/records/"))
                         }


### PR DESCRIPTION
Just a slight modification to the paragraph in the List Integration tab that explains what each background color means so that users who aren't in any of our servers can understand what they mean. Obviously the wording can be changed around if you would like.