### PR TITLE
Fix submitter list not being accessible to Moderators

### DIFF
--- a/pointercrate-demonlist-api/src/endpoints/submitter.rs
+++ b/pointercrate-demonlist-api/src/endpoints/submitter.rs
@@ -14,7 +14,7 @@ use rocket::serde::json::Json;
 
 #[rocket::get("/")]
 pub async fn paginate(mut auth: TokenAuth, pagination: Query<SubmitterPagination>) -> Result<Response2<Json<Vec<Submitter>>>> {
-    auth.require_permission(LIST_ADMINISTRATOR)?;
+    auth.require_permission(LIST_MODERATOR)?;
 
     let mut pagination = pagination.0;
 


### PR DESCRIPTION
On the submitters page, Moderators are able to view submitters with an exact ID, but they cannot view the list of submitters in the sidebar on the left. This PR should fix that issue. I’m not sure if there’s a particular reason that the permissions are like this, but it doesn’t make sense to me so I’m opening up a PR to fix this if this is unintended.