### PR TITLE
Better footer text

### DIFF
--- a/pointercrate-core-pages/src/footer.rs
+++ b/pointercrate-core-pages/src/footer.rs
@@ -89,7 +89,7 @@ impl Render for Footer {
                         (column)
                     }
                 }
-                div style="display: flex; justify-content: flex-end; align-items: center" {
+                div style="display: flex; justify-content: center; align-items: center" {
                     i class = "fab fa-twitter fa-2x" {}
                     (PreEscaped("&nbsp;&nbsp;Tweet Us:"))
                     @for link in &self.twitter_links {

--- a/pointercrate-core-pages/static/css/nav.css
+++ b/pointercrate-core-pages/static/css/nav.css
@@ -186,7 +186,7 @@ footer {
 
   width: 100%;
 
-  font-size: 0.5em;
+  font-size: 0.75em;
   font-weight: 300;
   text-align: center;
 
@@ -203,7 +203,7 @@ footer .flex {
 footer .flex > * {
   margin: 1% 1%;
   min-width: 150px;
-  max-width: 15%;
+  max-width: 35%;
 }
 
 footer a.link {

--- a/pointercrate-core-pages/static/css/nav.css
+++ b/pointercrate-core-pages/static/css/nav.css
@@ -203,7 +203,7 @@ footer .flex {
 footer .flex > * {
   margin: 1% 1%;
   min-width: 200px;
-  max-width: 35%;
+  max-width: 30%;
 }
 
 footer a.link {
@@ -228,7 +228,8 @@ footer * {
   }
 
   footer .flex {
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
   }
 
   footer .flex {

--- a/pointercrate-core-pages/static/css/nav.css
+++ b/pointercrate-core-pages/static/css/nav.css
@@ -202,7 +202,7 @@ footer .flex {
 
 footer .flex > * {
   margin: 1% 1%;
-  min-width: 200px;
+  min-width: 150px;
   max-width: 30%;
 }
 

--- a/pointercrate-core-pages/static/css/nav.css
+++ b/pointercrate-core-pages/static/css/nav.css
@@ -202,7 +202,7 @@ footer .flex {
 
 footer .flex > * {
   margin: 1% 1%;
-  min-width: 150px;
+  min-width: 200px;
   max-width: 35%;
 }
 


### PR DESCRIPTION
font is .75em instead of .5em + tos's text width is increased to 35%
+ the "tweet us" thing should use justify-content: center instead of flex-end, looks way nicer that way IMO

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
