### PR TITLE
Add a link to DLPS with a note stating list related inquiries should go there

### DIFF
--- a/pointercrate-demonlist-pages/src/account/list_integration.rs
+++ b/pointercrate-demonlist-pages/src/account/list_integration.rs
@@ -178,7 +178,7 @@ impl AccountPageTab for ListIntegrationTab {
                         "To initiate a claim, click the pen left of the 'Claimed Player' heading. Once initiated, you have an unverified claim on a player. These claims will then be manually verified by members of the pointercrate team. You can request verification in " a.link href=(self.0) {"this discord server"} "."
                         br;
                         b {
-                            "Note: for all list related inquiries including but not limitied to, record status, name changes, etc, you should use " a.link href=(self.1) {"this discord server"} "."
+                            "Note: for all list related inquiries including but not limited to, record status, name changes, etc, you should use " a.link href=(self.1) {"this discord server"} "."
                         }
                         br;
                         "You cannot initiate a claim on a player that already has a verified claim by a different user on it. "

--- a/pointercrate-demonlist-pages/src/account/list_integration.rs
+++ b/pointercrate-demonlist-pages/src/account/list_integration.rs
@@ -9,7 +9,7 @@ use pointercrate_demonlist::player::claim::PlayerClaim;
 use pointercrate_user::{sqlx::PgConnection, AuthenticatedUser, MODERATOR};
 use pointercrate_user_pages::account::AccountPageTab;
 
-pub struct ListIntegrationTab(#[doc = "discord invite url"] pub &'static str);
+pub struct ListIntegrationTab(#[doc = "discord invite url"] pub &'static str, #[doc = "discord invite url"] pub &'static str);
 
 #[async_trait::async_trait]
 impl AccountPageTab for ListIntegrationTab {
@@ -176,6 +176,10 @@ impl AccountPageTab for ListIntegrationTab {
                         "Player claiming is the process of associated a demonlist player with a pointercrate user account. A verified claim allows you to to modify some of the player's properties, such as nationality. "
                         br;
                         "To initiate a claim, click the pen left of the 'Claimed Player' heading. Once initiated, you have an unverified claim on a player. These claims will then be manually verified by members of the pointercrate team. You can request verification in " a.link href=(self.0) {"this discord server"} "."
+                        br;
+                        b {
+                            "Note: for all list related inquiries including but not limitied to, record status, name changes, etc, you should use " a.link href=(self.1) {"this discord server"} "."
+                        }
                         br;
                         "You cannot initiate a claim on a player that already has a verified claim by a different user on it. "
                     }

--- a/pointercrate-example/src/main.rs
+++ b/pointercrate-example/src/main.rs
@@ -74,7 +74,7 @@ async fn rocket() -> _ {
         // Tab where users can modify their own accounts
         .with_page(ProfileTab)
         // Tab where users can initiate player claims and manage their claimed players
-        .with_page(ListIntegrationTab("https://discord.gg/tMBzYP77ag"))
+        .with_page(ListIntegrationTab("https://discord.gg/tMBzYP77ag", "https://discord.gg/demonlist"))
         // Tab where website moderators can manage permissions. 
         // The vector below specified which permissions a user needs to have for the tab to be displayed.
         .with_page(UsersTab(vec![MODERATOR, LIST_ADMINISTRATOR]))


### PR DESCRIPTION
This aims to prevent people from joining Pointercrate Central to ask about list records instead of solely for verification request purposes.

The pointercrate-bin repo will also need a slight update.
https://github.com/stadust/pointercrate-bin/pull/3

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
