### PR TITLE
Cache stats viewer scores

### DIFF
--- a/migrations/20240504194923_cached_points.down.sql
+++ b/migrations/20240504194923_cached_points.down.sql
@@ -1,7 +1,65 @@
 -- Add down migration script here
+DROP VIEW ranked_players;
 
 ALTER TABLE players DROP COLUMN score;
 
-DROP FUNCTION recompute_all_scores();
+DROP FUNCTION recompute_player_scores();
 DROP FUNCTION score_of_player(player_id INTEGER);
 DROP VIEW score_giving;
+
+-- Copied from 20210419002933.up
+CREATE VIEW players_with_score AS
+SELECT players.id,
+       players.name,
+       RANK() OVER(ORDER BY scores.total_score DESC) AS rank,
+       CASE WHEN scores.total_score IS NULL THEN 0.0::FLOAT ELSE scores.total_score END AS score,
+       ROW_NUMBER() OVER(ORDER BY scores.total_score DESC) AS index,
+       nationalities.iso_country_code,
+       nationalities.nation,
+       players.subdivision,
+       nationalities.continent
+FROM
+    (
+        SELECT pseudo_records.player,
+               SUM(record_score(pseudo_records.progress::FLOAT, pseudo_records.position::FLOAT, 100::FLOAT, pseudo_records.requirement)) as total_score
+        FROM (
+                 SELECT player,
+                        progress,
+                        position,
+                        CASE WHEN demons.position > 75 THEN 100 ELSE requirement END AS requirement
+                 FROM records
+                          INNER JOIN demons
+                                     ON demons.id = demon
+                 WHERE demons.position <= 150 AND status_ = 'APPROVED' AND (demons.position <= 75 OR progress = 100)
+
+                 UNION
+
+                 SELECT verifier as player,
+                        CASE WHEN demons.position > 150 THEN 0.0::FLOAT ELSE 100.0::FLOAT END as progress,
+                        position,
+                        100.0::FLOAT
+                 FROM demons
+
+                 UNION
+
+                 SELECT publisher as player,
+                        0.0::FLOAT as progress,
+                        position,
+                        100.0::FLOAT
+                 FROM demons
+
+                 UNION
+
+                 SELECT creator as player,
+                        0.0::FLOAT as progress,
+                        1.0::FLOAT as position, -- doesn't matter
+                        100.0::FLOAT
+                 FROM creators
+             ) AS pseudo_records
+        GROUP BY player
+    ) scores
+        INNER JOIN players
+                   ON scores.player = players.id
+        LEFT OUTER JOIN nationalities
+                        ON players.nationality = nationalities.iso_country_code
+WHERE NOT players.banned AND players.id != 1534;

--- a/migrations/20240504194923_cached_points.down.sql
+++ b/migrations/20240504194923_cached_points.down.sql
@@ -2,9 +2,15 @@
 DROP VIEW ranked_players;
 
 ALTER TABLE players DROP COLUMN score;
+ALTER TABLE nationalities DROP COLUMN score;
+ALTER TABLE subdivisions DROP COLUMN score;
 
 DROP FUNCTION recompute_player_scores();
 DROP FUNCTION score_of_player(player_id INTEGER);
+DROP FUNCTION recompute_nation_scores();
+DROP FUNCTION score_of_nation(iso_country_code VARCHAR(2));
+DROP FUNCTION recompute_subdivision_scores();
+DROP FUNCTION score_of_subdivision(iso_country_code VARCHAR(2), iso_code VARCHAR(3));
 DROP VIEW score_giving;
 
 -- Copied from 20210419002933.up

--- a/migrations/20240504194923_cached_points.down.sql
+++ b/migrations/20240504194923_cached_points.down.sql
@@ -1,0 +1,7 @@
+-- Add down migration script here
+
+ALTER TABLE players DROP COLUMN score;
+
+DROP FUNCTION recompute_all_scores();
+DROP FUNCTION score_of_player(player_id INTEGER);
+DROP VIEW score_giving;

--- a/migrations/20240504194923_cached_points.down.sql
+++ b/migrations/20240504194923_cached_points.down.sql
@@ -14,6 +14,8 @@ DROP FUNCTION recompute_subdivision_scores();
 DROP FUNCTION score_of_subdivision(iso_country_code VARCHAR(2), iso_code VARCHAR(3));
 DROP VIEW score_giving;
 
+ALTER TABLE players DROP CONSTRAINT nation_subdivions_fkey;
+
 -- Copied from 20210419002933.up
 CREATE VIEW players_with_score AS
 SELECT players.id,

--- a/migrations/20240504194923_cached_points.down.sql
+++ b/migrations/20240504194923_cached_points.down.sql
@@ -111,3 +111,71 @@ CREATE VIEW nations_with_score AS
    ) scores
 INNER JOIN nationalities
         ON nationalities.iso_country_code = scores.nationality;
+
+-- Copied from 20210903174349
+CREATE OR REPLACE FUNCTION best_records_local(country VARCHAR(2), the_subdivision VARCHAR(3))
+    RETURNS TABLE (LIKE records)
+AS
+$body$
+WITH grp AS (
+    SELECT records.*,
+           RANK() OVER (PARTITION BY demon ORDER BY demon, progress DESC) AS rk
+    FROM records
+        INNER JOIN players
+            ON players.id = player
+    WHERE status_='APPROVED' AND players.nationality = country AND players.subdivision = the_subdivision
+)
+SELECT id, progress, video, status_, player, submitter, demon
+FROM grp
+WHERE rk = 1;
+$body$
+    LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION subdivision_ranking_of(country VARCHAR(2))
+    RETURNS TABLE (
+        rank BIGINT,
+        score FLOAT,
+        subdivision_code VARCHAR(3),
+        name TEXT
+    )
+AS
+    $body$
+    SELECT RANK() OVER(ORDER BY scores.total_score DESC) AS rank,
+           scores.total_score AS score,
+           iso_code,
+           name
+    FROM (
+        SELECT iso_code, name,
+                SUM(record_score(pseudo_records.progress::FLOAT, pseudo_records.position::FLOAT,
+                                 100::FLOAT, pseudo_records.requirement)) as total_score
+         FROM (
+                  select distinct on (iso_code, demon)
+                      iso_code,
+                      subdivisions.name,
+                      progress,
+                      position,
+                      CASE WHEN demons.position > 75 THEN 100 ELSE requirement END AS requirement
+                  from (
+                           select demon, player, progress
+                           from records
+                           where status_='APPROVED'
+
+                           union
+
+                           select id, verifier, 100
+                           from demons
+                       ) records
+                           inner join demons
+                                      on demons.id = records.demon
+                           inner join players
+                                      on players.id=records.player
+                           inner join subdivisions
+                                      on (iso_code=players.subdivision and players.nationality = nation)
+                  where position <= 150 and not players.banned and nation = country
+                  order by iso_code, demon, progress desc
+              ) AS pseudo_records
+         GROUP BY iso_code, name
+     ) scores;
+    $body$
+LANGUAGE SQL;
+

--- a/migrations/20240504194923_cached_points.up.sql
+++ b/migrations/20240504194923_cached_points.up.sql
@@ -42,3 +42,17 @@ CREATE FUNCTION recompute_player_scores() RETURNS void AS $$
 $$ LANGUAGE SQL;
 
 SELECT recompute_player_scores();
+
+DROP VIEW players_with_score;
+CREATE VIEW ranked_players AS 
+    SELECT 
+        ROW_NUMBER() OVER(ORDER BY score DESC, id) AS index,
+        RANK() OVER(ORDER BY score DESC) AS rank,
+        id, name, score, subdivision,
+        nationalities.iso_country_code,
+        nationalities.nation,
+        nationalities.continent
+    FROM players
+    LEFT OUTER JOIN nationalities
+                 ON players.nationality = nationalities.iso_country_code
+    WHERE NOT players.banned AND players.score > 0.0;

--- a/migrations/20240504194923_cached_points.up.sql
+++ b/migrations/20240504194923_cached_points.up.sql
@@ -124,3 +124,15 @@ CREATE FUNCTION recompute_subdivision_scores() RETURNS void AS $$
 $$ LANGUAGE SQL;
 
 SELECT recompute_subdivision_scores();
+
+DROP VIEW nations_with_score;
+CREATE VIEW ranked_nations AS 
+    SELECT 
+        ROW_NUMBER() OVER(ORDER BY score DESC, iso_country_code) AS index,
+        RANK() OVER(ORDER BY score DESC) AS rank,
+        score,
+        iso_country_code,
+        nation,
+        continent
+    FROM nationalities
+    WHERE score > 0.0;

--- a/migrations/20240504194923_cached_points.up.sql
+++ b/migrations/20240504194923_cached_points.up.sql
@@ -1,0 +1,44 @@
+-- Add up migration script here
+
+ALTER TABLE players ADD COLUMN score DOUBLE PRECISION DEFAULT 0 NOT NULL;
+
+CREATE VIEW score_giving AS
+    SELECT records.progress, demons.position, demons.requirement, records.player
+    FROM records
+    INNER JOIN demons
+    ON demons.id = records.demon
+    WHERE records.status_ = 'APPROVED'
+
+    UNION
+
+    SELECT 100, demons.position, demons.requirement, demons.verifier
+    FROM demons;
+
+CREATE FUNCTION score_of_player(player_id INTEGER) RETURNS DOUBLE PRECISION AS $$
+    SELECT SUM(record_score(progress, position, 150, requirement)) 
+    FROM score_giving
+    WHERE player = player_id
+$$ LANGUAGE SQL;
+
+-- This is slower than the old "select * from players_with_scores", but only needs to be called
+-- when demons are being moved around, so overall cheaper. Should this ever become a bottleneck for
+-- some obscure reason, we can separate the "score" column into a separate table, in which case the
+-- below function becomes a "TRUNCATE + INSERT q" on that new table (but then we'd pay the cost of 
+-- combining these via a JOIN when requesting the stats viewer).
+CREATE FUNCTION recompute_player_scores() RETURNS void AS $$ 
+    -- The nested query is faster than the more obvious "UPDATE players SET score = score_of_player(id)",
+    -- as the latter would essentially have runtime O(|records| * |players|), which this solution as
+    -- runtime O(|records| + |players|^2) [approximately, technically its |players| * |players where score > 0| 
+    -- and I'm sure the query planner is clever enough to not make it quadratic].
+    -- Since |records| >> |players|, this is faster.
+    UPDATE players 
+    SET score = coalesce(q.score, 0)
+    FROM (
+        SELECT player, SUM(record_score(progress, position, 150, requirement)) as score
+        FROM score_giving
+        GROUP BY player
+    ) q
+    WHERE q.player = id;
+$$ LANGUAGE SQL;
+
+SELECT recompute_player_scores();

--- a/migrations/20240504194923_cached_points.up.sql
+++ b/migrations/20240504194923_cached_points.up.sql
@@ -136,3 +136,7 @@ CREATE VIEW ranked_nations AS
         continent
     FROM nationalities
     WHERE score > 0.0;
+
+-- Now-unused functions
+DROP FUNCTION subdivision_ranking_of(country varchar(2));
+DROP FUNCTION best_records_local(country VARCHAR(2), the_subdivision VARCHAR(3));

--- a/migrations/20240504194923_cached_points.up.sql
+++ b/migrations/20240504194923_cached_points.up.sql
@@ -140,3 +140,6 @@ CREATE VIEW ranked_nations AS
 -- Now-unused functions
 DROP FUNCTION subdivision_ranking_of(country varchar(2));
 DROP FUNCTION best_records_local(country VARCHAR(2), the_subdivision VARCHAR(3));
+
+-- Hardening against invalid database state
+ALTER TABLE players ADD CONSTRAINT nation_subdivions_fkey FOREIGN KEY (nationality, subdivision) REFERENCES subdivisions (nation, iso_code);

--- a/pointercrate-demonlist-api/src/endpoints/player.rs
+++ b/pointercrate-demonlist-api/src/endpoints/player.rs
@@ -13,7 +13,7 @@ use pointercrate_demonlist::{
     nationality::Nationality,
     player::{
         claim::{ListedClaim, PatchPlayerClaim, PlayerClaim, PlayerClaimPagination},
-        DatabasePlayer, FullPlayer, PatchPlayer, Player, PlayerPagination, RankedPlayer, RankingPagination,
+        DatabasePlayer, FullPlayer, PatchPlayer, Player, PlayerPagination, RankingPagination, RankedPlayer
     },
     LIST_HELPER,
 };

--- a/pointercrate-demonlist-api/src/endpoints/player.rs
+++ b/pointercrate-demonlist-api/src/endpoints/player.rs
@@ -1,4 +1,5 @@
 use crate::{config, ratelimits::DemonlistRatelimits};
+use log::warn;
 use pointercrate_core::{error::CoreError, pool::PointercratePool};
 use pointercrate_core_api::{
     error::Result,
@@ -9,7 +10,7 @@ use pointercrate_core_api::{
 };
 use pointercrate_demonlist::{
     error::DemonlistError,
-    nationality::{nations_with_subdivisions, Nationality},
+    nationality::Nationality,
     player::{
         claim::{ListedClaim, PatchPlayerClaim, PlayerClaim, PlayerClaimPagination},
         DatabasePlayer, FullPlayer, PatchPlayer, Player, PlayerPagination, RankedPlayer, RankingPagination,
@@ -190,15 +191,21 @@ pub async fn geolocate_nationality(
         return Err(DemonlistError::VpsDetected.into());
     }
 
-    let nationality = Nationality::by_country_code_or_name(&data.country_code, &mut auth.connection).await?;
-
-    player.set_nationality(nationality, &mut auth.connection).await?;
-
-    if nations_with_subdivisions(&mut auth.connection).await?.contains(&data.country_code) {
-        if let Some(region) = data.region_iso_code {
-            player.set_subdivision(region, &mut auth.connection).await?;
-        }
+    let mut nationality = Nationality::by_country_code_or_name(&data.country_code, &mut auth.connection).await?;
+    if let Some(region) = data.region_iso_code {
+        nationality.subdivision = nationality
+            .subdivision_by_code(&region, &mut auth.connection)
+            .await
+            .inspect_err(|err| {
+                warn!(
+                    "No subdivision {} for nation {}, or nation does not support subdivisions: {:?}",
+                    region, nationality.iso_country_code, err
+                )
+            })
+            .ok();
     }
+
+    player.set_nationality(Some(nationality), &mut auth.connection).await?;
 
     auth.commit().await?;
 

--- a/pointercrate-demonlist-api/src/pages.rs
+++ b/pointercrate-demonlist-api/src/pages.rs
@@ -208,7 +208,7 @@ pub async fn heatmap_css(pool: &State<PointercratePool>) -> Result<Response2<Str
     let mut connection = pool.connection().await?;
     let mut css = heatmap_query!(
         connection,
-        r#"SELECT LOWER(iso_country_code) as "code!", score as "score!" from nations_with_score order by score desc"#,
+        r#"SELECT LOWER(iso_country_code) as "code!", score as "score!" from ranked_nations order by score desc"#,
     );
 
     for nation_iso_code in nations_with_subdivisions(&mut *connection).await? {

--- a/pointercrate-demonlist/sql/paginate_player_ranking.sql
+++ b/pointercrate-demonlist/sql/paginate_player_ranking.sql
@@ -1,5 +1,5 @@
-SELECT id, name::TEXT, rank, score, index, nation::TEXT, iso_country_code::TEXT
-FROM players_with_score
+SELECT index, rank, id, name, score, subdivision, iso_country_code, nation
+FROM ranked_players
 WHERE (index < $1 OR $1 IS NULL)
   AND (index > $2 OR $2 IS NULL)
   AND (STRPOS(name, $3::CITEXT) > 0 OR $3 is NULL)

--- a/pointercrate-demonlist/sql/paginate_players_by_id.sql
+++ b/pointercrate-demonlist/sql/paginate_players_by_id.sql
@@ -1,4 +1,4 @@
-SELECT id, name::TEXT, banned, nation::TEXT, iso_country_code::TEXT
+SELECT id, name::TEXT, banned, nation::TEXT, iso_country_code::TEXT, score
 FROM players
 LEFT OUTER JOIN nationalities ON nationality = iso_country_code
 WHERE (id < $1 OR $1 IS NULL)

--- a/pointercrate-demonlist/sql/paginate_players_by_id.sql
+++ b/pointercrate-demonlist/sql/paginate_players_by_id.sql
@@ -1,4 +1,4 @@
-SELECT id, name::TEXT, banned, nation::TEXT, iso_country_code::TEXT, score
+SELECT id, name::TEXT, banned, nation::TEXT, iso_country_code::TEXT, players.score
 FROM players
 LEFT OUTER JOIN nationalities ON nationality = iso_country_code
 WHERE (id < $1 OR $1 IS NULL)

--- a/pointercrate-demonlist/src/creator/get.rs
+++ b/pointercrate-demonlist/src/creator/get.rs
@@ -34,7 +34,7 @@ impl Creator {
 
 pub async fn creators_of(demon: &MinimalDemon, connection: &mut PgConnection) -> Result<Vec<DatabasePlayer>> {
     let mut stream = sqlx::query!(
-        r#"SELECT players.id, players.name AS "name: String", players.banned FROM players INNER JOIN creators ON players.id = creators.creator WHERE 
+        r#"SELECT players.id, players.name, players.banned FROM players INNER JOIN creators ON players.id = creators.creator WHERE 
          creators.demon = $1"#,
         demon.id
     )
@@ -57,7 +57,7 @@ pub async fn creators_of(demon: &MinimalDemon, connection: &mut PgConnection) ->
 pub async fn created_by(player_id: i32, connection: &mut PgConnection) -> Result<Vec<MinimalDemon>> {
     query_many_demons!(
         connection,
-        r#"SELECT demons.id, demons.name as "name: String", demons.position FROM demons INNER JOIN creators ON demons.id = creators.demon WHERE
+        r#"SELECT demons.id, demons.name, demons.position FROM demons INNER JOIN creators ON demons.id = creators.demon WHERE
          creators.creator=$1"#,
         player_id
     )

--- a/pointercrate-demonlist/src/demon/mod.rs
+++ b/pointercrate-demonlist/src/demon/mod.rs
@@ -199,18 +199,6 @@ impl Demon {
         Ok(())
     }
 
-    /// Decrements the position of all demons with positions equal to or smaller than the given one,
-    /// by one.
-    async fn shift_up(until: i16, connection: &mut PgConnection) -> Result<()> {
-        info!("Shifting up all demons until {}", until);
-
-        sqlx::query!("UPDATE demons SET position = position - 1 WHERE position <= $1", until)
-            .execute(connection)
-            .await?;
-
-        Ok(())
-    }
-
     /// Gets the current max position a demon has, or `CoreError::NotFound` if there are no demons
     /// in the database
     pub async fn max_position(connection: &mut PgConnection) -> Result<i16> {

--- a/pointercrate-demonlist/src/demon/mod.rs
+++ b/pointercrate-demonlist/src/demon/mod.rs
@@ -81,7 +81,7 @@ pub struct MinimalDemon {
 ///
 /// In addition to containing publisher/verifier information it also contains a list of the demon's
 /// creators and a list of accepted records
-#[derive(Debug, Serialize, Display, PartialEq, Eq, Hash)]
+#[derive(Debug, Serialize, Deserialize, Display, PartialEq, Eq, Hash)]
 #[display(fmt = "{}", demon)]
 pub struct FullDemon {
     #[serde(flatten)]

--- a/pointercrate-demonlist/src/demon/mod.rs
+++ b/pointercrate-demonlist/src/demon/mod.rs
@@ -199,7 +199,7 @@ impl Demon {
         Ok(())
     }
 
-    /// Gets the current max position a demon has, or `CoreError::NotFound` if there are no demons
+    /// Gets the current max position a demon has, or `0` if there are no demons
     /// in the database
     pub async fn max_position(connection: &mut PgConnection) -> Result<i16> {
         Ok(sqlx::query!("SELECT MAX(position) as max_position FROM demons")

--- a/pointercrate-demonlist/src/demon/patch.rs
+++ b/pointercrate-demonlist/src/demon/patch.rs
@@ -1,7 +1,7 @@
 use crate::{
     demon::{Demon, FullDemon, MinimalDemon},
     error::{DemonlistError, Result},
-    player::DatabasePlayer,
+    player::{recompute_player_scores, DatabasePlayer},
 };
 use log::{debug, info, warn};
 use pointercrate_core::util::{non_nullable, nullable};
@@ -95,8 +95,11 @@ impl Demon {
     pub async fn set_verifier(&mut self, verifier: DatabasePlayer, connection: &mut PgConnection) -> Result<()> {
         if verifier.id != self.verifier.id {
             sqlx::query!("UPDATE demons SET verifier = $1 WHERE id = $2", verifier.id, self.base.id)
-                .execute(connection)
+                .execute(&mut *connection)
                 .await?;
+
+            self.verifier.update_score(connection).await?;
+            verifier.update_score(connection).await?;
 
             self.verifier = verifier;
         }
@@ -237,12 +240,14 @@ impl MinimalDemon {
         debug!("Performing actual move to position {}", to);
 
         sqlx::query!("UPDATE demons SET position = $2 WHERE id = $1", self.id, to)
-            .execute(connection)
+            .execute(&mut *connection)
             .await?;
 
         info!("Moved demon {} from {} to {} successfully!", self, self.position, to);
 
         self.position = to;
+
+        recompute_player_scores(connection).await?;
 
         Ok(())
     }

--- a/pointercrate-demonlist/src/demon/patch.rs
+++ b/pointercrate-demonlist/src/demon/patch.rs
@@ -1,7 +1,7 @@
 use crate::{
     demon::{Demon, FullDemon, MinimalDemon},
     error::{DemonlistError, Result},
-    player::{recompute_player_scores, DatabasePlayer},
+    player::{recompute_scores, DatabasePlayer},
 };
 use log::{debug, info, warn};
 use pointercrate_core::util::{non_nullable, nullable};
@@ -247,7 +247,7 @@ impl MinimalDemon {
 
         self.position = to;
 
-        recompute_player_scores(connection).await?;
+        recompute_scores(connection).await?;
 
         Ok(())
     }

--- a/pointercrate-demonlist/src/demon/post.rs
+++ b/pointercrate-demonlist/src/demon/post.rs
@@ -2,7 +2,7 @@ use crate::{
     creator::Creator,
     demon::{Demon, FullDemon, MinimalDemon},
     error::Result,
-    player::{recompute_player_scores, DatabasePlayer},
+    player::{recompute_scores, DatabasePlayer},
 };
 use log::info;
 use serde::Deserialize;
@@ -74,7 +74,7 @@ impl FullDemon {
             creators.push(player);
         }
 
-        recompute_player_scores(connection).await?;
+        recompute_scores(connection).await?;
 
         Ok(FullDemon {
             demon,

--- a/pointercrate-demonlist/src/demon/post.rs
+++ b/pointercrate-demonlist/src/demon/post.rs
@@ -2,7 +2,7 @@ use crate::{
     creator::Creator,
     demon::{Demon, FullDemon, MinimalDemon},
     error::Result,
-    player::DatabasePlayer,
+    player::{recompute_player_scores, DatabasePlayer},
 };
 use log::info;
 use serde::Deserialize;
@@ -73,6 +73,8 @@ impl FullDemon {
 
             creators.push(player);
         }
+
+        recompute_player_scores(connection).await?;
 
         Ok(FullDemon {
             demon,

--- a/pointercrate-demonlist/src/nationality/get.rs
+++ b/pointercrate-demonlist/src/nationality/get.rs
@@ -237,15 +237,3 @@ pub async fn best_records_in(nation: &Nationality, connection: &mut PgConnection
 
     Ok(records)
 }
-
-/// Returns a list of ISO codes of countries that have subdivisions
-pub async fn nations_with_subdivisions(connection: &mut PgConnection) -> Result<Vec<String>> {
-    let mut nations = Vec::new();
-    let mut stream = sqlx::query!("SELECT DISTINCT nation FROM subdivisions").fetch(&mut *connection);
-
-    while let Some(row) = stream.next().await {
-        nations.push(row?.nation);
-    }
-
-    Ok(nations)
-}

--- a/pointercrate-demonlist/src/nationality/get.rs
+++ b/pointercrate-demonlist/src/nationality/get.rs
@@ -52,6 +52,28 @@ impl Nationality {
         })
     }
 
+    pub async fn subdivision_by_code(&self, code: &str, connection: &mut PgConnection) -> Result<Subdivision> {
+        let result = sqlx::query!(
+            "SELECT name FROM subdivisions WHERE iso_code = $1 AND nation = $2",
+            code,
+            self.iso_country_code
+        )
+        .fetch_one(&mut *connection)
+        .await;
+
+        match result {
+            Ok(row) => Ok(Subdivision {
+                iso_code: code.to_string(),
+                name: row.name,
+            }),
+            Err(sqlx::Error::RowNotFound) => Err(DemonlistError::SubdivisionNotFound {
+                nation_code: self.iso_country_code.clone(),
+                subdivision_code: code.to_string(),
+            }),
+            Err(err) => Err(err.into()),
+        }
+    }
+
     pub async fn all(connection: &mut PgConnection) -> Result<Vec<Nationality>> {
         let mut stream =
             sqlx::query!(r#"SELECT nation as "nation: String", iso_country_code as "iso_country_code: String" FROM nationalities"#)

--- a/pointercrate-demonlist/src/nationality/mod.rs
+++ b/pointercrate-demonlist/src/nationality/mod.rs
@@ -4,11 +4,12 @@ pub use get::nations_with_subdivisions;
 pub use paginate::{NationalityRankingPagination, RankedNation};
 use pointercrate_core::etag::Taggable;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use sqlx::PgConnection;
 
 mod get;
 mod paginate;
 
-#[derive(Debug, PartialEq, Eq, Serialize, Hash, Constructor, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Hash, Constructor, Deserialize, Clone)]
 pub struct Nationality {
     #[serde(rename = "country_code")]
     pub iso_country_code: String,

--- a/pointercrate-demonlist/src/nationality/mod.rs
+++ b/pointercrate-demonlist/src/nationality/mod.rs
@@ -127,3 +127,26 @@ impl Serialize for Continent {
         })
     }
 }
+
+impl Nationality {
+    /// Updates the score for this [`Nationality`] and contained [`Subdivision`] (if set).
+    pub async fn update_nation_score(&self, connection: &mut PgConnection) -> Result<(), sqlx::Error> {
+        sqlx::query!(
+            "UPDATE nationalities SET score = coalesce(score_of_nation($1), 0) FROM players WHERE iso_country_code = $1",
+            self.iso_country_code
+        )
+        .execute(&mut *connection)
+        .await?;
+        if let Some(ref subdivision) = self.subdivision {
+            sqlx::query!(
+                "UPDATE subdivisions SET score = coalesce(score_of_subdivision($1, $2), 0) FROM players WHERE nation = $1 AND iso_code = $2",
+                self.iso_country_code,
+                subdivision.iso_code
+            )
+            .execute(&mut *connection)
+            .await?;
+        }
+        
+        Ok(())
+    }
+}

--- a/pointercrate-demonlist/src/nationality/mod.rs
+++ b/pointercrate-demonlist/src/nationality/mod.rs
@@ -1,6 +1,5 @@
 use crate::demon::MinimalDemon;
 use derive_more::Constructor;
-pub use get::nations_with_subdivisions;
 pub use paginate::{NationalityRankingPagination, RankedNation};
 use pointercrate_core::etag::Taggable;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/pointercrate-demonlist/src/nationality/mod.rs
+++ b/pointercrate-demonlist/src/nationality/mod.rs
@@ -128,6 +128,11 @@ impl Serialize for Continent {
 }
 
 impl Nationality {
+    /// Checks whether [`self`] and `other` refer to the same country (but potentially different subdivisions)
+    pub fn same_country_as(&self, other: &Nationality) -> bool {
+        self.iso_country_code == other.iso_country_code
+    }
+
     /// Updates the score for this [`Nationality`] and contained [`Subdivision`] (if set).
     pub async fn update_nation_score(&self, connection: &mut PgConnection) -> Result<(), sqlx::Error> {
         sqlx::query!(

--- a/pointercrate-demonlist/src/nationality/paginate.rs
+++ b/pointercrate-demonlist/src/nationality/paginate.rs
@@ -27,8 +27,8 @@ pub struct RankedNation {
 impl NationalityRankingPagination {
     pub async fn page(&self, connection: &mut PgConnection) -> Result<Vec<RankedNation>> {
         let mut stream = sqlx::query!(
-            r#"SELECT rank as "rank!", score as "score!", nation::text as "nation!", iso_country_code as "iso_country_code!" FROM nations_with_score WHERE (STRPOS(nation, CAST($1::TEXT AS CITEXT)) > 
-             0 OR $1 is NULL) AND (continent = CAST($2::TEXT AS continent) OR $2 IS NULL)"#,
+            r#"SELECT rank as "rank!", score as "score!", nation as "nation!", iso_country_code as "iso_country_code!" FROM ranked_nations WHERE (STRPOS(nation, $1) > 
+             0 OR $1 is NULL) AND (continent::text = $2 OR $2 IS NULL)"#,
             self.name_contains,
             self.continent.map(|c| c.to_sql())
         )

--- a/pointercrate-demonlist/src/player/get.rs
+++ b/pointercrate-demonlist/src/player/get.rs
@@ -27,7 +27,7 @@ impl Player {
 
     pub async fn by_id(id: i32, connection: &mut PgConnection) -> Result<Player> {
         let result = sqlx::query!(
-            r#"SELECT id, players.name, banned, score, nationalities.nation::text, iso_country_code::text, iso_code::text as subdivision_code, subdivisions.name::text as subdivision_name FROM players LEFT OUTER JOIN nationalities ON 
+            r#"SELECT id, players.name, banned, players.score, nationalities.nation::text, iso_country_code::text, iso_code::text as subdivision_code, subdivisions.name::text as subdivision_name FROM players LEFT OUTER JOIN nationalities ON 
              players.nationality = nationalities.iso_country_code LEFT OUTER JOIN subdivisions ON players.subdivision = subdivisions.iso_code WHERE id = $1 AND (subdivisions.nation=nationalities.iso_country_code or players.subdivision is null)"#,
             id
         )

--- a/pointercrate-demonlist/src/player/get.rs
+++ b/pointercrate-demonlist/src/player/get.rs
@@ -8,16 +8,6 @@ use crate::{
 };
 use sqlx::{Error, PgConnection};
 
-// Required until https://github.com/launchbadge/sqlx/pull/108 is merged
-struct FetchedPlayer {
-    id: i32,
-    name: String,
-    banned: bool,
-    nation: Option<String>,
-    iso_country_code: Option<String>,
-    subdivision_name: Option<String>,
-    subdivision_code: Option<String>,
-}
 
 impl Player {
     pub async fn upgrade(self, connection: &mut PgConnection) -> Result<FullPlayer> {
@@ -36,8 +26,7 @@ impl Player {
     }
 
     pub async fn by_id(id: i32, connection: &mut PgConnection) -> Result<Player> {
-        let result = sqlx::query_as!(
-            FetchedPlayer,
+        let result = sqlx::query!(
             r#"SELECT id, players.name AS "name: String", banned, nationalities.nation::text, iso_country_code::text, iso_code::text as subdivision_code, subdivisions.name::text as subdivision_name FROM players LEFT OUTER JOIN nationalities ON 
              players.nationality = nationalities.iso_country_code LEFT OUTER JOIN subdivisions ON players.subdivision = subdivisions.iso_code WHERE id = $1 AND (subdivisions.nation=nationalities.iso_country_code or players.subdivision is null)"#,
             id

--- a/pointercrate-demonlist/src/player/get.rs
+++ b/pointercrate-demonlist/src/player/get.rs
@@ -58,6 +58,7 @@ impl Player {
                         name: row.name,
                         banned: row.banned,
                     },
+                    score: row.score,
                     nationality,
                 })
             },

--- a/pointercrate-demonlist/src/player/get.rs
+++ b/pointercrate-demonlist/src/player/get.rs
@@ -27,7 +27,7 @@ impl Player {
 
     pub async fn by_id(id: i32, connection: &mut PgConnection) -> Result<Player> {
         let result = sqlx::query!(
-            r#"SELECT id, players.name AS "name: String", banned, nationalities.nation::text, iso_country_code::text, iso_code::text as subdivision_code, subdivisions.name::text as subdivision_name FROM players LEFT OUTER JOIN nationalities ON 
+            r#"SELECT id, players.name, banned, score, nationalities.nation::text, iso_country_code::text, iso_code::text as subdivision_code, subdivisions.name::text as subdivision_name FROM players LEFT OUTER JOIN nationalities ON 
              players.nationality = nationalities.iso_country_code LEFT OUTER JOIN subdivisions ON players.subdivision = subdivisions.iso_code WHERE id = $1 AND (subdivisions.nation=nationalities.iso_country_code or players.subdivision is null)"#,
             id
         )
@@ -71,19 +71,15 @@ impl DatabasePlayer {
     pub async fn by_name(name: &str, connection: &mut PgConnection) -> Result<DatabasePlayer> {
         let name = name.trim();
 
-        let result = sqlx::query!(
-            "SELECT id, name::text, banned FROM players WHERE name = cast($1::text as citext)",
-            name.to_string()
-        ) // FIXME(sqlx) once CITEXT is supported
+        let result = sqlx::query_as!(DatabasePlayer,
+            "SELECT id, name, banned FROM players WHERE name = $1",
+            name
+        )
         .fetch_one(connection)
         .await;
 
         match result {
-            Ok(row) => Ok(DatabasePlayer {
-                id: row.id,
-                name: row.name.unwrap(), // FIXME(sqlx) casted columns interpreted as nullable
-                banned: row.banned,
-            }),
+            Ok(player) => Ok(player),
             Err(Error::RowNotFound) => Err(DemonlistError::PlayerNotFoundName {
                 player_name: name.to_string(),
             }),
@@ -92,16 +88,12 @@ impl DatabasePlayer {
     }
 
     pub async fn by_id(id: i32, connection: &mut PgConnection) -> Result<DatabasePlayer> {
-        let result = sqlx::query!(r#"SELECT id, name as "name: String", banned FROM players WHERE id = $1"#, id)
+        let result = sqlx::query_as!(DatabasePlayer, r#"SELECT id, name, banned FROM players WHERE id = $1"#, id)
             .fetch_one(connection)
             .await;
 
         match result {
-            Ok(row) => Ok(DatabasePlayer {
-                id: row.id,
-                name: row.name,
-                banned: row.banned,
-            }),
+            Ok(player) => Ok(player),
             Err(Error::RowNotFound) => Err(DemonlistError::PlayerNotFound { player_id: id }),
             Err(err) => Err(err.into()),
         }
@@ -112,7 +104,7 @@ impl DatabasePlayer {
 
         match Self::by_name(name, connection).await {
             Err(DemonlistError::PlayerNotFoundName { .. }) => {
-                let id = sqlx::query!("INSERT INTO players (name) VALUES ($1::text) RETURNING id", name.to_string())
+                let id = sqlx::query!("INSERT INTO players (name) VALUES ($1) RETURNING id", name.to_string())
                     .fetch_one(connection)
                     .await?
                     .id;

--- a/pointercrate-demonlist/src/player/mod.rs
+++ b/pointercrate-demonlist/src/player/mod.rs
@@ -4,8 +4,9 @@ pub use self::{
 };
 use crate::{demon::MinimalDemon, nationality::Nationality, record::MinimalRecordD};
 use derive_more::Display;
-use pointercrate_core::etag::Taggable;
+use pointercrate_core::{error::CoreError, etag::Taggable};
 use serde::{Deserialize, Serialize};
+use sqlx::PgConnection;
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
@@ -53,12 +54,28 @@ pub struct Player {
     #[serde(flatten)]
     pub base: DatabasePlayer,
 
+    /// This [`Player`]'s score on the stats viewer
+    ///
+    /// This value is cached in the `score` column of the `players` table, and not computed on-demand!
+    /// Thus it needs to be updated on any event that can affect a player's score. These are
+    /// - Record updates
+    ///   * Record status updated (to approved, or from approved)
+    ///   * Record progress updated
+    ///   * Record holder updated
+    ///   * Record Added
+    /// - Demon updates
+    ///   * Demon movement/addition (recompute all scores)
+    ///   * Demon requirement updated (recompute all scores)
+    ///   * Demon verifier updated
+    /// - Player updates
+    ///   * Player banned
+    ///   * Player objects merged
     pub score: f64,
     pub nationality: Option<Nationality>,
 }
 
 // `f64` does not implement hash. Most things in the pointercrate frontend only display score with an accuracy of two digits after the dot,
-// so hashing only this part should be fine for ETag purposes. 
+// so hashing only this part should be fine for ETag purposes.
 impl Hash for Player {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.base.hash(state);
@@ -73,4 +90,23 @@ impl Taggable for FullPlayer {
         self.player.hash(&mut hasher);
         hasher.finish()
     }
+}
+
+impl DatabasePlayer {
+    /// Recomputes this player's score and updates it in the database.
+    pub async fn update_score(&self, connection: &mut PgConnection) -> Result<f64, CoreError> {
+        // No need to specially handle banned players - they have no approved records, so `score_of_player` will return 0
+        let new_score = sqlx::query!(
+            "UPDATE players SET score = coalesce(score_of_player($1), 0) WHERE id = $1 RETURNING score",
+            self.id
+        )
+        .fetch_one(connection)
+        .await?;
+        Ok(new_score.score)
+    }
+}
+
+pub async fn recompute_player_scores(connection: &mut PgConnection) -> Result<(), CoreError> {
+    sqlx::query!("SELECT recompute_player_scores();").execute(connection).await?;
+    Ok(())
 }

--- a/pointercrate-demonlist/src/player/mod.rs
+++ b/pointercrate-demonlist/src/player/mod.rs
@@ -1,5 +1,5 @@
 pub use self::{
-    paginate::{PlayerPagination, RankingPagination},
+    paginate::{PlayerPagination, RankingPagination, RankedPlayer},
     patch::PatchPlayer,
 };
 use crate::{demon::MinimalDemon, nationality::Nationality, record::MinimalRecordD};
@@ -34,18 +34,6 @@ pub struct FullPlayer {
     pub created: Vec<MinimalDemon>,
     pub verified: Vec<MinimalDemon>,
     pub published: Vec<MinimalDemon>,
-}
-
-#[derive(Debug, PartialEq, Serialize, Display)]
-#[display(fmt = "{} (ID: {}) at rank {} with score {}", name, id, rank, score)]
-pub struct RankedPlayer {
-    pub id: i32,
-    pub name: String,
-    pub rank: i64,
-    pub score: f64,
-    pub nationality: Option<Nationality>,
-    #[serde(skip)]
-    pub index: i64,
 }
 
 #[derive(Debug, PartialEq, Serialize, Display, Deserialize)]

--- a/pointercrate-demonlist/src/player/mod.rs
+++ b/pointercrate-demonlist/src/player/mod.rs
@@ -24,7 +24,7 @@ pub struct DatabasePlayer {
     pub banned: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, Display, PartialEq, Eq, Hash)]
+#[derive(Debug, Serialize, Deserialize, Display, PartialEq, Hash)]
 #[display(fmt = "{}", player)]
 pub struct FullPlayer {
     #[serde(flatten)]
@@ -47,13 +47,24 @@ pub struct RankedPlayer {
     pub index: i64,
 }
 
-#[derive(Debug, Eq, Hash, PartialEq, Serialize, Display, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Display, Deserialize)]
 #[display(fmt = "{}", base)]
 pub struct Player {
     #[serde(flatten)]
     pub base: DatabasePlayer,
 
+    pub score: f64,
     pub nationality: Option<Nationality>,
+}
+
+// `f64` does not implement hash. Most things in the pointercrate frontend only display score with an accuracy of two digits after the dot,
+// so hashing only this part should be fine for ETag purposes. 
+impl Hash for Player {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.base.hash(state);
+        ((self.score * 100f64) as u64).hash(state);
+        self.nationality.hash(state);
+    }
 }
 
 impl Taggable for FullPlayer {

--- a/pointercrate-demonlist/src/player/paginate.rs
+++ b/pointercrate-demonlist/src/player/paginate.rs
@@ -82,6 +82,7 @@ impl Paginatable<PlayerPagination> for Player {
                     name: row.get("name"),
                     banned: row.get("banned"),
                 },
+                score: row.get("score"),
                 nationality,
             })
         }

--- a/pointercrate-demonlist/src/player/paginate.rs
+++ b/pointercrate-demonlist/src/player/paginate.rs
@@ -1,6 +1,6 @@
 use crate::{
     nationality::{Continent, Nationality},
-    player::{DatabasePlayer, Player, RankedPlayer},
+    player::{DatabasePlayer, Player},
 };
 use futures::StreamExt;
 use pointercrate_core::{
@@ -126,12 +126,21 @@ impl PaginationQuery for RankingPagination {
     }
 }
 
+#[derive(Debug, Serialize)]
+pub struct RankedPlayer {
+    rank: i64,
+    #[serde(skip)]
+    index: i64,
+    #[serde(flatten)]
+    player: Player,
+}
+
 impl Paginatable<RankingPagination> for RankedPlayer {
     async fn first_and_last(connection: &mut PgConnection) -> Result<Option<(i32, i32)>, sqlx::Error> {
-        Ok(sqlx::query!("SELECT MAX(index) FROM players_with_score")
+        Ok(sqlx::query!("SELECT COUNT(*) FROM players WHERE NOT banned AND score > 0.0")
             .fetch_one(connection)
             .await?
-            .max
+            .count
             .map(|max| (1, max as i32)))
     }
 
@@ -165,13 +174,20 @@ impl Paginatable<RankingPagination> for RankedPlayer {
                 _ => None,
             };
 
-            players.push(RankedPlayer {
-                id: row.get("id"),
-                name: row.get("name"),
-                rank: row.get("rank"),
-                nationality,
+            let player = Player {
+                base: DatabasePlayer {
+                    id: row.get("id"),
+                    name: row.get("name"),
+                    banned: false,
+                },
                 score: row.get("score"),
+                nationality,
+            };
+
+            players.push(RankedPlayer {
+                rank: row.get("rank"),
                 index: row.get("index"),
+                player,
             })
         }
 

--- a/pointercrate-demonlist/src/player/patch.rs
+++ b/pointercrate-demonlist/src/player/patch.rs
@@ -231,9 +231,12 @@ impl Player {
             subdivision_code,
             self.base.id
         )
-        .execute(connection)
+        .execute(&mut *connection)
         .await?;
 
+        if let Some(ref mut nationality) = self.nationality {
+            nationality.update_nation_score(connection).await?;
+        }
         self.nationality = nationality;
 
         Ok(())

--- a/pointercrate-demonlist/src/player/patch.rs
+++ b/pointercrate-demonlist/src/player/patch.rs
@@ -35,7 +35,13 @@ impl FullPlayer {
         match new_nationality {
             Some(ref mut nationality) => {
                 nationality.subdivision = match patch.subdivision {
-                    None => self.player.nationality.as_ref().map(|n| n.subdivision.clone()).unwrap_or(None),
+                    None => self
+                        .player
+                        .nationality
+                        .as_ref()
+                        .filter(|n| n.same_country_as(nationality))
+                        .map(|n| n.subdivision.clone())
+                        .unwrap_or(None),
                     Some(None) => None,
                     Some(Some(subdivision_code)) => Some(nationality.subdivision_by_code(&subdivision_code, connection).await?),
                 }

--- a/pointercrate-demonlist/src/player/patch.rs
+++ b/pointercrate-demonlist/src/player/patch.rs
@@ -64,6 +64,8 @@ impl FullPlayer {
             self.set_name(name, connection).await?;
         }
 
+        self.player.score = self.player.base.update_score(connection).await?;
+
         Ok(self)
     }
 

--- a/pointercrate-demonlist/src/record/get.rs
+++ b/pointercrate-demonlist/src/record/get.rs
@@ -61,7 +61,7 @@ impl FullRecord {
 pub async fn approved_records_by(player: &DatabasePlayer, connection: &mut PgConnection) -> Result<Vec<MinimalRecordD>> {
     let mut stream = sqlx::query!(
         r#"SELECT records.id, progress, CASE WHEN players.link_banned THEN NULL ELSE records.video::text END, demons.id AS demon_id, 
-         demons.name as "name: String", demons.position FROM records INNER JOIN demons ON records.demon = demons.id INNER JOIN players ON players.id 
+         demons.name, demons.position FROM records INNER JOIN demons ON records.demon = demons.id INNER JOIN players ON players.id 
          = $1 WHERE status_ = 'APPROVED' AND records.player = $1"#,
         player.id
     )
@@ -103,7 +103,7 @@ pub async fn approved_records_on(demon: &MinimalDemon, connection: &mut PgConnec
     let mut stream = sqlx::query_as!(
         Fetched,
         r#"SELECT records.id, progress, CASE WHEN players.link_banned THEN NULL ELSE video::text END, players.id AS player_id, 
-         players.name AS "name: String", players.banned, nation::TEXT, iso_country_code::TEXT FROM records INNER JOIN players ON records.player = players.id LEFT OUTER JOIN nationalities ON nationality = iso_country_code WHERE status_ = 'APPROVED' AND 
+         players.name, players.banned, nation::TEXT, iso_country_code::TEXT FROM records INNER JOIN players ON records.player = players.id LEFT OUTER JOIN nationalities ON nationality = iso_country_code WHERE status_ = 'APPROVED' AND 
          records.demon = $1 ORDER BY progress DESC, id ASC"#,
         demon.id
     )

--- a/pointercrate-demonlist/src/record/mod.rs
+++ b/pointercrate-demonlist/src/record/mod.rs
@@ -171,7 +171,7 @@ pub struct MinimalRecordD {
     pub demon: MinimalDemon,
 }
 
-#[derive(Debug, Hash, Serialize, Display, PartialEq, Eq)]
+#[derive(Debug, Hash, Serialize, Deserialize, Display, PartialEq, Eq)]
 #[display(fmt = "{} - {}% (ID: {})", player, progress, id)]
 pub struct MinimalRecordP {
     pub id: i32,

--- a/pointercrate-demonlist/src/record/post.rs
+++ b/pointercrate-demonlist/src/record/post.rs
@@ -219,6 +219,10 @@ impl ValidatedSubmission {
             .await?;
         }
 
+        if self.status != RecordStatus::Submitted {
+            record.player.update_score(connection).await?;
+        }
+
         Ok(record)
     }
 }

--- a/pointercrate-test/src/demonlist.rs
+++ b/pointercrate-test/src/demonlist.rs
@@ -1,10 +1,15 @@
-use crate::TestClient;
+use crate::{TestClient, TestRequest};
+use pointercrate_core::etag::Taggable;
 use pointercrate_core::{permission::PermissionsManager, pool::PointercratePool};
 use pointercrate_demonlist::{
-    player::claim::PlayerClaim, record::RecordStatus, submitter::Submitter, LIST_ADMINISTRATOR, LIST_HELPER, LIST_MODERATOR,
+    player::{claim::PlayerClaim, FullPlayer},
+    record::RecordStatus,
+    submitter::Submitter,
+    LIST_ADMINISTRATOR, LIST_HELPER, LIST_MODERATOR,
 };
+use pointercrate_user::AuthenticatedUser;
 use pointercrate_user_pages::account::AccountPageConfig;
-use rocket::local::asynchronous::Client;
+use rocket::{http::Status, local::asynchronous::Client};
 use sqlx::{pool::PoolConnection, PgConnection, Pool, Postgres};
 use std::{net::IpAddr, str::FromStr};
 
@@ -86,4 +91,20 @@ pub async fn add_simple_record(progress: i16, player: i32, demon: i32, status: R
     .await
     .unwrap()
     .id
+}
+
+impl TestClient {
+    pub async fn patch_player(&self, player_id: i32, auth_context: &AuthenticatedUser, patch: serde_json::Value) -> TestRequest {
+        let player: FullPlayer = self
+            .get(format!("/api/v1/players/{}/", player_id))
+            .expect_status(Status::Ok)
+            .get_success_result()
+            .await;
+
+        self
+            .patch(format!("/api/v1/players/{}/", player_id), &patch)
+            .authorize_as(&auth_context)
+            .header("If-Match", player.etag_string())
+            .expect_status(Status::Ok)
+    }
 }

--- a/pointercrate-test/src/demonlist.rs
+++ b/pointercrate-test/src/demonlist.rs
@@ -1,6 +1,7 @@
 use crate::{TestClient, TestRequest};
 use pointercrate_core::etag::Taggable;
 use pointercrate_core::{permission::PermissionsManager, pool::PointercratePool};
+use pointercrate_demonlist::demon::FullDemon;
 use pointercrate_demonlist::{
     player::{claim::PlayerClaim, FullPlayer},
     record::RecordStatus,
@@ -101,10 +102,20 @@ impl TestClient {
             .get_success_result()
             .await;
 
-        self
-            .patch(format!("/api/v1/players/{}/", player_id), &patch)
+        self.patch(format!("/api/v1/players/{}/", player_id), &patch)
             .authorize_as(&auth_context)
             .header("If-Match", player.etag_string())
             .expect_status(Status::Ok)
+    }
+
+    pub async fn add_demon(
+        &self, auth_context: &AuthenticatedUser, name: impl Into<String>, position: i16, requirement: i16, verifier: impl Into<String>,
+        publisher: impl Into<String>,
+    ) -> FullDemon {
+        self.post("/api/v2/demons/", &serde_json::json!({"name": name.into(), "position": position, "requirement": requirement, "verifier": verifier.into(), "publisher": publisher.into(), "creators": []}))
+            .expect_status(Status::Created)
+            .authorize_as(&auth_context)
+            .get_success_result()
+            .await
     }
 }

--- a/pointercrate-test/tests/demonlist/player.rs
+++ b/pointercrate-test/tests/demonlist/player.rs
@@ -1,4 +1,3 @@
-use pointercrate_core::etag::Taggable;
 use pointercrate_demonlist::{
     nationality::{Nationality, Subdivision},
     player::{DatabasePlayer, FullPlayer, Player},
@@ -71,27 +70,28 @@ async fn test_patch_player_nationality(pool: Pool<Postgres>) {
     let player = DatabasePlayer::by_name_or_create("stardust1971", &mut *connection).await.unwrap();
     let user = pointercrate_test::user::system_user_with_perms(LIST_HELPER, &mut *connection).await;
 
-    let etag = Player::by_id(player.id, &mut *connection)
+    // Try to set subdivision when no nation is set. Should fail.
+    let result: serde_json::Value = client.patch_player(player.id, &user, serde_json::json!({"subdivision": "ENG"}))
         .await
-        .unwrap()
-        .upgrade(&mut *connection)
-        .await
-        .unwrap()
-        .etag_string();
+        .expect_status(Status::Conflict)
+        .get_result()
+        .await;
 
-    let json: FullPlayer = client
-        .patch(
-            format!("/api/v1/players/{}/", player.id),
-            &serde_json::json!({"nationality": "United Kingdom", "subdivision": "ENG"}),
+    assert_eq!(result["code"], 40907);
+
+    // Patch both nationality and subdivision
+    let patched_player: FullPlayer = client
+        .patch_player(
+            player.id,
+            &user,
+            serde_json::json!({"nationality": "United Kingdom", "subdivision": "ENG"}),
         )
-        .authorize_as(&user)
-        .header("If-Match", etag)
-        .expect_status(Status::Ok)
+        .await
         .get_success_result()
         .await;
 
     assert_eq!(
-        json.player.nationality,
+        patched_player.player.nationality,
         Some(Nationality {
             iso_country_code: "GB".into(),
             nation: "United Kingdom".into(),
@@ -101,4 +101,67 @@ async fn test_patch_player_nationality(pool: Pool<Postgres>) {
             })
         })
     );
+
+    // Patch only subdivision, nationality should remain untouched
+    let patched_player: FullPlayer = client
+        .patch_player(
+            player.id,
+            &user,
+            serde_json::json!({"nationality": "United Kingdom", "subdivision": "SCT"}),
+        )
+        .await
+        .get_success_result()
+        .await;
+
+    assert_eq!(
+        patched_player.player.nationality,
+        Some(Nationality {
+            iso_country_code: "GB".into(),
+            nation: "United Kingdom".into(),
+            subdivision: Some(Subdivision {
+                iso_code: "SCT".into(),
+                name: "Scotland".into()
+            })
+        })
+    );
+
+    // Patch nation, but to the one we already have. Shouldn't change anything.
+    client
+        .patch_player(player.id, &user, serde_json::json!({"nationality": "United Kingdom"}))
+        .await
+        .expect_status(Status::NotModified)
+        .execute()
+        .await;
+
+    // Patch only nationality. Should reset subdivision
+    let patched_player: FullPlayer = client
+        .patch_player(player.id, &user, serde_json::json!({"nationality": "Germany"}))
+        .await
+        .get_success_result()
+        .await;
+
+    assert_eq!(
+        patched_player.player.nationality,
+        Some(Nationality {
+            iso_country_code: "DE".into(),
+            nation: "Germany".into(),
+            subdivision: None
+        })
+    );
+
+    // Nonsense nationality/subdivision combo should be rejected
+    let result: serde_json::Value = client
+        .patch_player(
+            player.id,
+            &user,
+            serde_json::json!({"nationality": "Belgium", "subdivision": "ENG"}),
+        )
+        .await
+        .expect_status(Status::NotFound)
+        .get_result()
+        .await;
+
+    assert_eq!(result["code"], 40401);
+    assert_eq!(result["data"]["nation_code"], "BE");
+    assert_eq!(result["data"]["subdivision_code"], "ENG");
 }

--- a/pointercrate-test/tests/demonlist/player/mod.rs
+++ b/pointercrate-test/tests/demonlist/player/mod.rs
@@ -6,6 +6,8 @@ use pointercrate_demonlist::{
 use rocket::http::Status;
 use sqlx::{PgConnection, Pool, Postgres};
 
+mod score;
+
 async fn create_players(connection: &mut PgConnection) -> (DatabasePlayer, DatabasePlayer) {
     let mut banned = DatabasePlayer::by_name_or_create("stardust1971", &mut *connection).await.unwrap();
     banned.ban(&mut *connection).await.unwrap();

--- a/pointercrate-test/tests/demonlist/player/score.rs
+++ b/pointercrate-test/tests/demonlist/player/score.rs
@@ -1,0 +1,136 @@
+//! Module containing all score related test cases (because I suspect over time there will be quite a few)
+
+use pointercrate_core::etag::Taggable;
+use pointercrate_demonlist::{
+    player::{DatabasePlayer, FullPlayer},
+    record::FullRecord,
+    LIST_MODERATOR,
+};
+use rocket::http::Status;
+use sqlx::{PgConnection, Pool, Postgres};
+
+#[sqlx::test(migrations = "../migrations")]
+pub async fn test_score_update_on_record_update(pool: Pool<Postgres>) {
+    let (clnt, mut connection) = pointercrate_test::demonlist::setup_rocket(pool).await;
+
+    let helper = pointercrate_test::user::system_user_with_perms(LIST_MODERATOR, &mut *connection).await;
+    let player = DatabasePlayer::by_name_or_create("stardust1971", &mut *connection).await.unwrap();
+    let demon = clnt.add_demon(&helper, "Bloodbath", 1, 100, "stardust1972", "stardust1972").await;
+
+    let submission = serde_json::json! {{"progress": 100, "demon": demon.demon.base.id, "player": "stardust1971", "video": "https://youtube.com/watch?v=1234567890", "status": "Approved"}};
+
+    let record = clnt
+        .post("/api/v1/records", &submission)
+        .authorize_as(&helper)
+        .expect_status(Status::Ok)
+        .get_success_result::<FullRecord>()
+        .await;
+
+    let player: FullPlayer = clnt
+        .get(format!("/api/v1/players/{}", player.id))
+        .expect_status(Status::Ok)
+        .get_success_result()
+        .await;
+
+    assert_ne!(player.player.score, 0.0f64, "Adding approved record failed to give player score");
+
+    clnt.patch(
+        format!("/api/v1/records/{}/", record.id),
+        &serde_json::json!({"status": "Rejected"}),
+    )
+    .authorize_as(&helper)
+    .header("If-Match", record.etag_string())
+    .expect_status(Status::Ok)
+    .execute()
+    .await;
+
+    let player: FullPlayer = clnt
+        .get(format!("/api/v1/players/{}", player.player.base.id))
+        .expect_status(Status::Ok)
+        .get_success_result()
+        .await;
+
+    assert_eq!(player.player.score, 0.0f64, "Rejecting record failed to remove player score");
+}
+
+#[sqlx::test(migrations = "../migrations")]
+pub async fn test_verifications_give_score(pool: Pool<Postgres>) {
+    let (clnt, mut connection) = pointercrate_test::demonlist::setup_rocket(pool).await;
+
+    let helper = pointercrate_test::user::system_user_with_perms(LIST_MODERATOR, &mut *connection).await;
+    let demon = clnt.add_demon(&helper, "Bloodbath", 1, 100, "stardust1971", "stardust1971").await;
+
+    let player: FullPlayer = clnt
+        .get(format!("/api/v1/players/{}", demon.demon.verifier.id))
+        .expect_status(Status::Ok)
+        .get_success_result()
+        .await;
+
+    assert_ne!(player.player.score, 0.0f64);
+}
+
+async fn nationality_score(iso_country_code: &str, connection: &mut PgConnection) -> f64 {
+    sqlx::query!("SELECT score FROM nationalities WHERE iso_country_code = $1", iso_country_code)
+        .fetch_one(&mut *connection)
+        .await
+        .unwrap()
+        .score
+}
+
+async fn subdivision_score(nation: &str, iso_code: &str, connection: &mut PgConnection) -> f64 {
+    sqlx::query!(
+        "SELECT score FROM subdivisions WHERE nation = $1 AND iso_code = $2",
+        nation,
+        iso_code
+    )
+    .fetch_one(&mut *connection)
+    .await
+    .unwrap()
+    .score
+}
+
+#[sqlx::test(migrations = "../migrations")]
+pub async fn test_player_score_reflects_to_nationality(pool: Pool<Postgres>) {
+    let (clnt, mut connection) = pointercrate_test::demonlist::setup_rocket(pool).await;
+
+    let helper = pointercrate_test::user::system_user_with_perms(LIST_MODERATOR, &mut *connection).await;
+    let demon = clnt.add_demon(&helper, "Bloodbath", 1, 100, "stardust1971", "stardust1971").await;
+
+    clnt.patch_player(
+        demon.demon.verifier.id,
+        &helper,
+        serde_json::json!({"nationality": "GB", "subdivision": "ENG"}),
+    )
+    .await
+    .execute()
+    .await;
+
+    assert_ne!(nationality_score("GB", &mut connection).await, 0f64);
+    assert_ne!(subdivision_score("GB", "ENG", &mut connection).await, 0f64);
+
+    clnt.patch_player(
+        demon.demon.verifier.id,
+        &helper,
+        serde_json::json!({"subdivision": "SCT"}),
+    )
+    .await
+    .execute()
+    .await;
+
+    assert_ne!(nationality_score("GB", &mut connection).await, 0f64);
+    assert_eq!(subdivision_score("GB", "ENG", &mut connection).await, 0f64);
+    assert_ne!(subdivision_score("GB", "SCT", &mut connection).await, 0f64);
+
+    clnt.patch_player(
+        demon.demon.verifier.id,
+        &helper,
+        serde_json::json!({"nationality": "DE"}),
+    )
+    .await
+    .execute()
+    .await;
+
+    assert_eq!(nationality_score("GB", &mut connection).await, 0f64);
+    assert_eq!(subdivision_score("GB", "SCT", &mut connection).await, 0f64);
+    assert_ne!(nationality_score("DE", &mut connection).await, 0f64);
+}

--- a/pointercrate-test/tests/demonlist/record.rs
+++ b/pointercrate-test/tests/demonlist/record.rs
@@ -126,7 +126,7 @@ async fn submit_existing_record(pool: Pool<Postgres>) {
     let existing = pointercrate_test::demonlist::add_simple_record(70, player1.id, demon1, RecordStatus::Approved, &mut *connection).await;
 
     let submission =
-        serde_json::json! {{"progress": 60, "demon": demon1, "player": "stardust1971", "video": "https://youtube.com/watch?v=1234567890"}};
+        serde_json::json! {{"progress": 60, "demon": demon1, "player": "stardust1971", "video": "https://youtube.com/watch?v=1234567890", "raw_footage": "https://pointercrate.com"}};
 
     let json: serde_json::Value = clnt
         .post("/api/v1/records/", &submission)


### PR DESCRIPTION
Cache all player scores in a new column of the `players` table, to improve performance of stats viewer. 

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
