### PR TITLE
Add a proper way to reset search filters in the record manager

### DIFF
--- a/pointercrate-demonlist-pages/src/account/records.rs
+++ b/pointercrate-demonlist-pages/src/account/records.rs
@@ -259,7 +259,7 @@ fn player_selector() -> Markup {
                 "Filter by player"
             }
             p {
-                "Players can be uniquely identified by name and ID. Entering either in the appropriate place below will filter the view on the left. Right now the only way to reset this filter is to reload the page. Sorry!"
+                "Players can be uniquely identified by name and ID. Entering either in the appropriate place below will filter the view on the left. Reset by clicking \"Find ...\" when the text field is empty."
             }
             form.flex.col.underlined.pad #record-filter-by-player-id-form novalidate = "" {
                 p.info-red.output {}

--- a/pointercrate-demonlist-pages/static/js/account/records.js
+++ b/pointercrate-demonlist-pages/static/js/account/records.js
@@ -301,9 +301,9 @@ function setupRecordFilterPlayerIdForm() {
   );
   var playerId = recordFilterPlayerIdForm.input("record-player-id");
 
-  playerId.addValidator(valueMissing, "Player ID required");
   recordFilterPlayerIdForm.onSubmit(function () {
-    recordManager.updateQueryData("player", playerId.value);
+    // Reset search filter if player ID field is empty
+    recordManager.updateQueryData("player", valueMissing(playerId) ? playerId.value : undefined);
   });
 }
 
@@ -327,12 +327,12 @@ function setupRecordFilterPlayerNameForm() {
   );
   var playerName = recordFilterPlayerNameForm.input("record-player-name");
 
-  playerName.addValidators({
-    "Player name required": valueMissing,
-  });
-
   recordFilterPlayerNameForm.onSubmit(function () {
-    get("/api/v1/players/?name=" + playerName.value)
+    if (!valueMissing(playerName)) {
+      // Player name field is empty, so reset search filter
+      recordManager.updateQueryData("player", undefined);
+    } else {
+      get("/api/v1/players/?name=" + playerName.value)
       .then((response) => {
         let json = response.data;
 
@@ -343,6 +343,7 @@ function setupRecordFilterPlayerNameForm() {
         }
       })
       .catch(displayError(recordFilterPlayerNameForm));
+    }
   });
 }
 


### PR DESCRIPTION
Now you can reset the player ID and name search filters by leaving the field empty and searching

Resolves #141 

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
