### PR TITLE
feat: add `/players/me` endpoint (#191)

### DIFF
--- a/pointercrate-demonlist-api/src/lib.rs
+++ b/pointercrate-demonlist-api/src/lib.rs
@@ -44,6 +44,7 @@ pub fn setup(rocket: Rocket<Build>) -> Rocket<Build> {
             "/api/v1/players/",
             rocket::routes![
                 endpoints::player::get,
+                endpoints::player::get_me,
                 endpoints::player::paginate,
                 endpoints::player::patch,
                 endpoints::player::ranking,


### PR DESCRIPTION
Add `/players/me` that returns the `FullPlayer` linked to the authenticated user.
Returns 401 if unauthenticated (duh).
Returns 404 if no claim exists.

Closes #191.

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
