### PR TITLE
Fix nation stats viewer tooltip from only displaying one creator per demon

### DIFF
--- a/pointercrate-demonlist/src/nationality/get.rs
+++ b/pointercrate-demonlist/src/nationality/get.rs
@@ -150,7 +150,7 @@ pub async fn unbeaten_in(nation: &Nationality, connection: &mut PgConnection) ->
 }
 
 pub async fn created_in(nation: &Nationality, connection: &mut PgConnection) -> Result<Vec<MiniDemonWithPlayers>> {
-    let mut stream = sqlx::query!( r#"select distinct on (demon) demon, demons.name::text as "demon_name!", demons.position, players.name::text as "player_name!" from creators inner join demons on demons.id=demon inner join players on players.id=creator where nationality=$1"#, nation.iso_country_code).fetch(connection);
+    let mut stream = sqlx::query!( r#"select (demon) demon, demons.name::text as "demon_name!", demons.position, players.name::text as "player_name!" from creators inner join demons on demons.id=demon inner join players on players.id=creator where nationality=$1"#, nation.iso_country_code).fetch(connection);
 
     let mut creations = Vec::<MiniDemonWithPlayers>::new();
 

--- a/pointercrate-demonlist/src/nationality/get.rs
+++ b/pointercrate-demonlist/src/nationality/get.rs
@@ -150,7 +150,7 @@ pub async fn unbeaten_in(nation: &Nationality, connection: &mut PgConnection) ->
 }
 
 pub async fn created_in(nation: &Nationality, connection: &mut PgConnection) -> Result<Vec<MiniDemonWithPlayers>> {
-    let mut stream = sqlx::query!( r#"select (demon) demon, demons.name::text as "demon_name!", demons.position, players.name::text as "player_name!" from creators inner join demons on demons.id=demon inner join players on players.id=creator where nationality=$1"#, nation.iso_country_code).fetch(connection);
+    let mut stream = sqlx::query!( r#"select demon, demons.name::text as "demon_name!", demons.position, players.name::text as "player_name!" from creators inner join demons on demons.id=demon inner join players on players.id=creator where nationality=$1 order by demon"#, nation.iso_country_code).fetch(connection);
 
     let mut creations = Vec::<MiniDemonWithPlayers>::new();
 


### PR DESCRIPTION
Fixed the `created_in` function only retrieving one creator per demon. In the previous SQL statement, every retrieved demon was unique, causing this to happen:
![image](https://github.com/user-attachments/assets/452c3f38-117e-49f5-ab26-98c0e9d1cd47)

Removing the `DISTINCT ON` statement allowed multiple creators of the same demon to be retrieved:
![image](https://github.com/user-attachments/assets/58bc64da-c6e1-462f-8c6e-0984989ef848)

Resolves #178 


## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
