### PR TITLE
Ability to sort stats viewer demons

### DIFF
--- a/pointercrate-demonlist-pages/src/statsviewer/individual.rs
+++ b/pointercrate-demonlist-pages/src/statsviewer/individual.rs
@@ -42,6 +42,7 @@ impl IndividualStatsViewer {
                     (stats_viewer_html(Some(&self.nationalities_in_use), super::standard_stats_viewer_rows()))
                 }
                 aside.right {
+                    (super::demon_sorting_mode_panel())
                     (super::continent_panel())
                     (super::hide_subdivision_panel())
                     section.panel.fade style = "overflow: initial;" {

--- a/pointercrate-demonlist-pages/src/statsviewer/mod.rs
+++ b/pointercrate-demonlist-pages/src/statsviewer/mod.rs
@@ -32,7 +32,7 @@ fn demon_sorting_mode_panel() -> Markup {
             p {
                 "The order in which demons are listed on stats viewer profiles"
             }
-            (simple_dropdown("demonsortingmode-dropdown", Some("Alphabetical"), vec!["Position"].into_iter()))
+            (simple_dropdown("demonsortingmode-dropdown", Some("Position"), vec!["Alphabetical"].into_iter()))
         }
     }
 }

--- a/pointercrate-demonlist-pages/src/statsviewer/mod.rs
+++ b/pointercrate-demonlist-pages/src/statsviewer/mod.rs
@@ -23,6 +23,20 @@ pub(crate) fn stats_viewer_panel() -> Markup {
     }
 }
 
+fn demon_sorting_mode_panel() -> Markup {
+    html! {
+        section.panel.fade style="overflow:initial" {
+            h3.underlined {
+                "Demon Sorting"
+            }
+            p {
+                "The order in which completed demons are listed on stats viewer profiles"
+            }
+            (simple_dropdown("demonsortingmode-dropdown", Some("Alphabetical"), vec!["Position"].into_iter()))
+        }
+    }
+}
+
 fn continent_panel() -> Markup {
     html! {
         section.panel.fade style="overflow:initial"{

--- a/pointercrate-demonlist-pages/src/statsviewer/mod.rs
+++ b/pointercrate-demonlist-pages/src/statsviewer/mod.rs
@@ -30,7 +30,7 @@ fn demon_sorting_mode_panel() -> Markup {
                 "Demon Sorting"
             }
             p {
-                "The order in which completed demons are listed on stats viewer profiles"
+                "The order in which demons are listed on stats viewer profiles"
             }
             (simple_dropdown("demonsortingmode-dropdown", Some("Alphabetical"), vec!["Position"].into_iter()))
         }

--- a/pointercrate-demonlist-pages/src/statsviewer/national.rs
+++ b/pointercrate-demonlist-pages/src/statsviewer/national.rs
@@ -38,6 +38,7 @@ fn nation_based_stats_viewer_html() -> Markup {
                 (stats_viewer_html(None, rows))
             }
             aside.right {
+                (super::demon_sorting_mode_panel())
                 (super::continent_panel())
             }
         }

--- a/pointercrate-demonlist-pages/static/js/modules/statsviewer.js
+++ b/pointercrate-demonlist-pages/static/js/modules/statsviewer.js
@@ -49,6 +49,8 @@ export class StatsViewer extends FilteredPaginator {
     this._progress = document.getElementById("progress");
     this._content = html.getElementsByClassName("viewer-content")[0];
 
+    this.demonSortingMode = "Alphabetical";
+
     let dropdownElement = html.getElementsByClassName("dropdown-menu")[0];
 
     if (dropdownElement !== undefined) {

--- a/pointercrate-demonlist-pages/static/js/modules/statsviewer.js
+++ b/pointercrate-demonlist-pages/static/js/modules/statsviewer.js
@@ -49,7 +49,7 @@ export class StatsViewer extends FilteredPaginator {
     this._progress = document.getElementById("progress");
     this._content = html.getElementsByClassName("viewer-content")[0];
 
-    this.demonSortingMode = "Alphabetical";
+    this.demonSortingMode = "Position";
 
     let dropdownElement = html.getElementsByClassName("dropdown-menu")[0];
 

--- a/pointercrate-demonlist-pages/static/js/statsviewer/individual.js
+++ b/pointercrate-demonlist-pages/static/js/statsviewer/individual.js
@@ -25,13 +25,17 @@ class IndividualStatsViewer extends StatsViewer {
 
     this.setName(playerData.name, playerData.nationality);
 
+    this.populateStatsContainers(this.demonSortingMode);
+  }
+
+  populateStatsContainers(demonSortingMode) {
+    var playerData = this.currentObject;
+    
     this.formatDemonsInto(this._created, playerData.created);
     this.formatDemonsInto(this._published, playerData.published);
     this.formatDemonsInto(this._verified, playerData.verified);
 
     let beaten = playerData.records.filter((record) => record.progress === 100);
-
-    beaten.sort((r1, r2) => r1.demon.name.localeCompare(r2.demon.name));
 
     let legacy = beaten.filter(
       (record) => record.demon.position > this.extended_list_size
@@ -50,6 +54,12 @@ class IndividualStatsViewer extends StatsViewer {
     let verifiedLegacy = playerData.verified.filter(
       (demon) => demon.position > this.extended_list_size
     ).length;
+
+    if (demonSortingMode === "Alphabetical") {
+      beaten.sort((r1, r2) => r1.demon.name.localeCompare(r2.demon.name));
+    } else if (demonSortingMode === "Position") {
+      beaten.sort((r1, r2) => r1.demon.position - r2.demon.position);
+    }
 
     this.formatRecordsInto(this._beaten, beaten);
     this.setCompletionNumber(
@@ -123,6 +133,14 @@ $(window).on("load", function () {
     document.getElementById("statsviewer")
   );
   window.statsViewer.initialize();
+
+  new Dropdown(document.getElementById("demonsortingmode-dropdown")).addEventListener(
+    (selected) => {
+      window.statsViewer.demonSortingMode = selected;
+
+      if (window.statsViewer.currentObject) { window.statsViewer.populateStatsContainers(selected); }
+    }
+  );
 
   new Dropdown(document.getElementById("continent-dropdown")).addEventListener(
     (selected) => {

--- a/pointercrate-demonlist-pages/static/js/statsviewer/individual.js
+++ b/pointercrate-demonlist-pages/static/js/statsviewer/individual.js
@@ -30,10 +30,6 @@ class IndividualStatsViewer extends StatsViewer {
 
   populateStatsContainers(demonSortingMode) {
     var playerData = this.currentObject;
-    
-    this.formatDemonsInto(this._created, playerData.created);
-    this.formatDemonsInto(this._published, playerData.published);
-    this.formatDemonsInto(this._verified, playerData.verified);
 
     let beaten = playerData.records.filter((record) => record.progress === 100);
 
@@ -57,9 +53,19 @@ class IndividualStatsViewer extends StatsViewer {
 
     if (demonSortingMode === "Alphabetical") {
       beaten.sort((r1, r2) => r1.demon.name.localeCompare(r2.demon.name));
+      playerData.created.sort((r1, r2) => d1.name.localeCompare(r2.name));
+      playerData.published.sort((r1, r2) => r1.name.localeCompare(r2.name));
+      playerData.verified.sort((r1, r2) => r1.name.localeCompare(r2.name));
     } else if (demonSortingMode === "Position") {
       beaten.sort((r1, r2) => r1.demon.position - r2.demon.position);
+      playerData.created.sort((r1, r2) => r1.position - r2.position);
+      playerData.published.sort((r1, r2) => r1.position - r2.position);
+      playerData.verified.sort((r1, r2) => r1.position - r2.position);
     }
+
+    this.formatDemonsInto(this._created, playerData.created);
+    this.formatDemonsInto(this._published, playerData.published);
+    this.formatDemonsInto(this._verified, playerData.verified);
 
     this.formatRecordsInto(this._beaten, beaten);
     this.setCompletionNumber(

--- a/pointercrate-demonlist-pages/static/js/statsviewer/nation.js
+++ b/pointercrate-demonlist-pages/static/js/statsviewer/nation.js
@@ -91,13 +91,19 @@ class NationStatsViewer extends StatsViewer {
 
     if (demonSortingMode === "Alphabetical") {
       beaten.sort((r1, r2) => r1.demon.localeCompare(r2.demon));
+      nationData.unbeaten.sort((r1, r2) => r1.name.localeCompare(r2.name));
+      nationData.created.sort((r1, r2) => r1.demon.localeCompare(r2.demon));
+      nationData.published.sort((r1, r2) => r1.demon.localeCompare(r2.demon));
+      nationData.verified.sort((r1, r2) => r1.demon.localeCompare(r2.demon));
     } else if (demonSortingMode === "Position") {
       beaten.sort((r1, r2) => r1.position - r2.position);
+      nationData.unbeaten.sort((r1, r2) => r1.position - r2.position);
+      nationData.created.sort((r1, r2) => r1.position - r2.position);
+      nationData.published.sort((r1, r2) => r1.position - r2.position);
+      nationData.verified.sort((r1, r2) => r1.position - r2.position);
     }
 
-    nationData.unbeaten.sort((r1, r2) => r1.name.localeCompare(r2.name));
     progress.sort((r1, r2) => r2.progress - r1.progress);
-    nationData.created.sort((r1, r2) => r1.demon.localeCompare(r2.demon));
 
     formatInto(
       this._unbeaten,

--- a/pointercrate-demonlist-pages/static/js/statsviewer/nation.js
+++ b/pointercrate-demonlist-pages/static/js/statsviewer/nation.js
@@ -25,6 +25,12 @@ class NationStatsViewer extends StatsViewer {
 
     this.setName(nationData.nation.nation, nationData.nation);
 
+    this.populateStatsContainers(this.demonSortingMode);
+  }
+
+  populateStatsContainers(demonSortingMode) {
+    let nationData = this.currentObject;
+
     let beaten = [];
     let progress = [];
 
@@ -83,8 +89,13 @@ class NationStatsViewer extends StatsViewer {
     this.setHardest(hardest);
     this.setCompletionNumber(amountBeaten, extended, legacy);
 
+    if (demonSortingMode === "Alphabetical") {
+      beaten.sort((r1, r2) => r1.demon.localeCompare(r2.demon));
+    } else if (demonSortingMode === "Position") {
+      beaten.sort((r1, r2) => r1.position - r2.position);
+    }
+
     nationData.unbeaten.sort((r1, r2) => r1.name.localeCompare(r2.name));
-    beaten.sort((r1, r2) => r1.demon.localeCompare(r2.demon));
     progress.sort((r1, r2) => r2.progress - r1.progress);
     nationData.created.sort((r1, r2) => r1.demon.localeCompare(r2.demon));
 
@@ -205,6 +216,14 @@ $(window).on("load", function () {
       if (li.dataset.id === country) window.statsViewer.onSelect(li);
     }
   });
+
+  new Dropdown(document.getElementById("demonsortingmode-dropdown")).addEventListener(
+    (selected) => {
+      window.statsViewer.demonSortingMode = selected;
+
+      if (window.statsViewer.currentObject) { window.statsViewer.populateStatsContainers(selected); }
+    }
+  )
 
   new Dropdown(document.getElementById("continent-dropdown")).addEventListener(
     (selected) => {


### PR DESCRIPTION
An implementation of #208, adds a dropdown on the right of the individual and nation stats viewers

![image](https://github.com/user-attachments/assets/7a3d5890-6f33-48de-b359-ee09c8cc6b5a)

`populateStatsViewer` being its own function allows the containers to be repopulated without sending another request

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
