### PR TITLE
Add dropdown to sort completed demons on stats viewers

### DIFF
--- a/pointercrate-core-pages/static/js/modules/form.js
+++ b/pointercrate-core-pages/static/js/modules/form.js
@@ -102,9 +102,9 @@ export class Dropdown {
     else this.input.value = null;
   }
 
-  select(entry) {
+  select(entry, reselect = false) {
     if (entry in this.values) {
-      if (entry === this.selected) return;
+      if (entry === this.selected && !reselect) return;
 
       this.selected = entry;
       this.input.value = this.values[entry];

--- a/pointercrate-demonlist-api/src/pages.rs
+++ b/pointercrate-demonlist-api/src/pages.rs
@@ -153,7 +153,7 @@ pub async fn demon_page(position: i16, pool: &State<PointercratePool>, gd: &Stat
 #[rocket::get("/statsviewer")]
 pub async fn stats_viewer(pool: &State<PointercratePool>) -> Result<Page> {
     let mut connection = pool.connection().await?;
-
+    
     Ok(Page::new(IndividualStatsViewer {
         nationalities_in_use: Nationality::used(&mut *connection).await?,
     }))

--- a/pointercrate-demonlist-pages/src/statsviewer/individual.rs
+++ b/pointercrate-demonlist-pages/src/statsviewer/individual.rs
@@ -42,6 +42,7 @@ impl IndividualStatsViewer {
                     (stats_viewer_html(Some(&self.nationalities_in_use), super::standard_stats_viewer_rows()))
                 }
                 aside.right {
+                    (super::demon_sorting_panel())
                     (super::continent_panel())
                     (super::hide_subdivision_panel())
                     section.panel.fade style = "overflow: initial;" {

--- a/pointercrate-demonlist-pages/src/statsviewer/mod.rs
+++ b/pointercrate-demonlist-pages/src/statsviewer/mod.rs
@@ -37,6 +37,20 @@ fn continent_panel() -> Markup {
     }
 }
 
+fn demon_sorting_panel() -> Markup {
+    html! {
+        section.panel.fade style="overflow:initial" {
+            h3.underlined {
+                "Demon Sorting"
+            }
+            p {
+                "The order in which completed demons should be listed"
+            }
+            (simple_dropdown("demon-sorting-mode-dropdown", Some("Alphabetical"), vec!["Position"].into_iter()))
+        }
+    }
+}
+
 fn hide_subdivision_panel() -> Markup {
     html! {
         section.panel.fade {
@@ -62,6 +76,9 @@ fn standard_stats_viewer_rows() -> Vec<StatsViewerRow> {
         StatsViewerRow(vec![("Demonlist rank", "rank"), ("Demonlist score", "score")]),
         StatsViewerRow(vec![("Demonlist stats", "stats"), ("Hardest demon", "hardest")]),
         StatsViewerRow(vec![("Demons completed", "beaten")]),
+        StatsViewerRow(vec![("Main Demons completed", "main-beaten")]),
+        StatsViewerRow(vec![("Extended Demons completed", "extended-beaten")]),
+        StatsViewerRow(vec![("Legacy Demons completed", "legacy-beaten")]),
         StatsViewerRow(vec![
             ("Demons created", "created"),
             ("Demons published", "published"),

--- a/pointercrate-demonlist-pages/src/statsviewer/national.rs
+++ b/pointercrate-demonlist-pages/src/statsviewer/national.rs
@@ -38,6 +38,7 @@ fn nation_based_stats_viewer_html() -> Markup {
                 (stats_viewer_html(None, rows))
             }
             aside.right {
+                (super::demon_sorting_panel())
                 (super::continent_panel())
             }
         }

--- a/pointercrate-demonlist-pages/static/js/modules/statsviewer.js
+++ b/pointercrate-demonlist-pages/static/js/modules/statsviewer.js
@@ -39,6 +39,9 @@ export class StatsViewer extends FilteredPaginator {
     this._name = document.getElementById("player-name");
     this._created = document.getElementById("created");
     this._beaten = document.getElementById("beaten");
+    this._main_beaten = document.getElementById("main-beaten");
+    this._extended_beaten = document.getElementById("extended-beaten");
+    this._legacy_beaten = document.getElementById("legacy-beaten");
     this._verified = document.getElementById("verified");
     this._published = document.getElementById("published");
     this._hardest = document.getElementById("hardest");
@@ -61,6 +64,28 @@ export class StatsViewer extends FilteredPaginator {
         }
       });
     }
+
+    let demonSortingModeDropdown = new Dropdown(document.getElementById("demon-sorting-mode-dropdown"));
+    
+    demonSortingModeDropdown.addEventListener(
+      (selected) => {
+        window.localStorage.setItem("demon_sorting_mode", selected);
+  
+        if (selected === "Alphabetical") {
+          this._main_beaten.parentElement.parentElement.style.display = "none";
+          this._extended_beaten.parentElement.parentElement.style.display = "none"
+          this._legacy_beaten.parentElement.parentElement.style.display = "none"
+          this._beaten.parentElement.parentElement.style.display = "block"
+        } else {
+          this._main_beaten.parentElement.parentElement.style.display = "block"
+          this._extended_beaten.parentElement.parentElement.style.display = "block"
+          this._legacy_beaten.parentElement.parentElement.style.display = "block"
+          this._beaten.parentElement.parentElement.style.display = "none"
+        }
+      }
+    ); 
+
+    demonSortingModeDropdown.select(localStorage.getItem("demon_sorting_mode") ?? "Alphabetical", true); // default to alphabetical
   }
 
   initialize() {
@@ -128,16 +153,20 @@ export class StatsViewer extends FilteredPaginator {
       this.currentlySelected.getElementsByTagName("i")[0].innerHTML;
   }
 
-  formatDemon(demon, link) {
+  formatDemon(demon, link, dontStyle) {
     var element;
 
-    if (demon.position <= this.list_size) {
-      element = document.createElement("b");
-    } else if (demon.position <= this.extended_list_size) {
+    if (dontStyle) {
       element = document.createElement("span");
     } else {
-      element = document.createElement("i");
-      element.style.opacity = ".5";
+      if (demon.position <= this.list_size) {
+        element = document.createElement("b");
+      } else if (demon.position <= this.extended_list_size) {
+        element = document.createElement("span");
+      } else {
+        element = document.createElement("i");
+        element.style.opacity = ".5";
+      }
     }
 
     let a = document.createElement("a");

--- a/pointercrate-demonlist-pages/static/js/statsviewer/individual.js
+++ b/pointercrate-demonlist-pages/static/js/statsviewer/individual.js
@@ -31,16 +31,25 @@ class IndividualStatsViewer extends StatsViewer {
 
     let beaten = playerData.records.filter((record) => record.progress === 100);
 
-    beaten.sort((r1, r2) => r1.demon.name.localeCompare(r2.demon.name));
-
     let legacy = beaten.filter(
       (record) => record.demon.position > this.extended_list_size
-    ).length;
+    );
     let extended = beaten.filter(
       (record) =>
         record.demon.position > this.list_size &&
         record.demon.position <= this.extended_list_size
-    ).length;
+    );
+    let main = beaten.filter(
+      (record) => record.demon.position <= this.list_size
+    );
+
+    beaten.sort((r1, r2) => r1.demon.name.localeCompare(r2.demon.name));
+    this.formatRecordsInto(this._beaten, beaten);
+    
+    beaten.sort((r1, r2) => r1.demon.position - r2.demon.position);
+    this.formatRecordsInto(this._main_beaten, main, true);
+    this.formatRecordsInto(this._extended_beaten, extended, true);
+    this.formatRecordsInto(this._legacy_beaten, legacy, true);
 
     let verifiedExtended = playerData.verified.filter(
       (demon) =>
@@ -51,16 +60,13 @@ class IndividualStatsViewer extends StatsViewer {
       (demon) => demon.position > this.extended_list_size
     ).length;
 
-    this.formatRecordsInto(this._beaten, beaten);
     this.setCompletionNumber(
-      beaten.length -
-        legacy -
-        extended +
+      main.length +
         playerData.verified.length -
         verifiedExtended -
         verifiedLegacy,
-      extended + verifiedExtended,
-      legacy + verifiedLegacy
+      extended.length + verifiedExtended,
+      legacy.length + verifiedLegacy
     );
 
     let hardest = playerData.verified
@@ -86,11 +92,11 @@ class IndividualStatsViewer extends StatsViewer {
     );
   }
 
-  formatRecordsInto(element, records) {
+  formatRecordsInto(element, records, dontStyle) {
     formatInto(
       element,
       records.map((record) => {
-        let demon = this.formatDemon(record.demon, record.video);
+        let demon = this.formatDemon(record.demon, record.video, dontStyle);
         if (record.progress !== 100) {
           demon.appendChild(
             document.createTextNode(" (" + record.progress + "%)")
@@ -117,6 +123,7 @@ $(window).on("load", function () {
   window.statsViewer = new IndividualStatsViewer(
     document.getElementById("statsviewer")
   );
+
   window.statsViewer.initialize();
 
   new Dropdown(document.getElementById("continent-dropdown")).addEventListener(

--- a/pointercrate-demonlist-pages/static/js/statsviewer/nation.js
+++ b/pointercrate-demonlist-pages/static/js/statsviewer/nation.js
@@ -75,8 +75,33 @@ class NationStatsViewer extends StatsViewer {
     this.setHardest(hardest);
     this.setCompletionNumber(amountBeaten, extended, legacy);
 
-    nationData.unbeaten.sort((r1, r2) => r1.name.localeCompare(r2.name));
     beaten.sort((r1, r2) => r1.demon.name.localeCompare(r2.demon.name));
+    formatInto(
+      this._beaten,
+      beaten.map((record) => this.formatDemonFromRecord(record))
+    );
+
+    beaten.sort((r1, r2) => r1.demon.position - r2.demon.position);
+    formatInto(
+      this._main_beaten,
+      beaten
+        .filter((record) => record.demon.position <= this.list_size)
+        .map((record) => this.formatDemonFromRecord(record, true))
+    );
+    formatInto(
+      this._extended_beaten,
+      beaten
+        .filter((record) => record.demon.position > this.list_size && record.demon.position <= this.extended_list_size)
+        .map((record) => this.formatDemonFromRecord(record, true))
+    );
+    formatInto(
+      this._legacy_beaten,
+      beaten
+        .filter((record) => record.demon.position > this.extended_list_size)
+        .map((record) => this.formatDemonFromRecord(record, true))
+    );
+
+    nationData.unbeaten.sort((r1, r2) => r1.name.localeCompare(r2.name));
     progress.sort((r1, r2) => r2.progress - r1.progress);
     nationData.created.sort((r1, r2) =>
       r1.demon.name.localeCompare(r2.demon.name)
@@ -85,10 +110,6 @@ class NationStatsViewer extends StatsViewer {
     formatInto(
       this._unbeaten,
       nationData.unbeaten.map((demon) => this.formatDemon(demon))
-    );
-    formatInto(
-      this._beaten,
-      beaten.map((record) => this.formatDemonFromRecord(record))
     );
     formatInto(
       this._progress,
@@ -149,8 +170,8 @@ class NationStatsViewer extends StatsViewer {
     return tooltip;
   }
 
-  formatDemonFromRecord(record) {
-    let baseElement = this.formatDemon(record.demon);
+  formatDemonFromRecord(record, dontStyle) {
+    let baseElement = this.formatDemon(record.demon, null, dontStyle);
 
     if (record.progress !== 100)
       baseElement.appendChild(
@@ -165,7 +186,7 @@ class NationStatsViewer extends StatsViewer {
       (record.players.length === 1 ? "" : "s") +
       "&nbsp;in&nbsp;this&nbsp;country: ";
 
-    return this.makeTooltip(baseElement, title, record.players.join(", "));
+    return this.makeTooltip(baseElement, title, record.players.join(", "), dontStyle);
   }
 }
 


### PR DESCRIPTION
An implementation of #208, adds a dropdown which allows the user to choose between two sorting options

![image](https://github.com/user-attachments/assets/a0f8ac81-b273-4178-82c5-f670019d2947)

The selected value is saved in cookies, where the default value of the `simple_dropdown` is set to the cookie value.

In the Javascript (only in the `IndividualStatsViewer` class), the code that populates the stats containers is moved from the `onReceive` function to its own `populateStatsContainers` function, so the stats containers can be repopulated without sending another request

Currently, it's only implemented in the individual stats viewer, but I could see this feature being nice to have in the nation stats viewer as well so I'm open to making changes

I'm not entirely sure if handling all of the cookie stuff in the backend is the greatest idea, my second thought would be to just modify the dropdown's selected value to the cookie value (or maybe just a value in `localStorage`) once it's initialized in the JS, but I'm not quite sure


## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
