### PR TITLE
Support subdivision filtering on `/players` paginated endpoint

### DIFF
--- a/pointercrate-demonlist/sql/paginate_players_by_id.sql
+++ b/pointercrate-demonlist/sql/paginate_players_by_id.sql
@@ -1,11 +1,13 @@
-SELECT id, name::TEXT, banned, nation::TEXT, iso_country_code::TEXT, players.score
+SELECT id, players.name::TEXT, banned, nationalities.nation::TEXT, iso_country_code::TEXT, subdivision::TEXT AS iso_code, subdivisions.name AS subdivision_name, players.score
 FROM players
 LEFT OUTER JOIN nationalities ON nationality = iso_country_code
+LEFT JOIN subdivisions ON iso_code = subdivision AND subdivisions.nation = nationality
 WHERE (id < $1 OR $1 IS NULL)
   AND (id > $2 OR $2 IS NULL)
-  AND (name = $3::CITEXT OR $3 is NULL)
-  AND (STRPOS(name, $4::CITEXT) > 0 OR $4 is NULL)
+  AND (players.name = $3::CITEXT OR $3 is NULL)
+  AND (STRPOS(players.name, $4::CITEXT) > 0 OR $4 is NULL)
   AND (banned = $5 OR $5 IS NULL)
   AND (nationality = $6 OR iso_country_code = $6 OR (nationality IS NULL AND $7) OR ($6 IS NULL AND NOT $7))
+  AND (subdivision = $8 OR $8 IS NULL)
 ORDER BY id {}
-LIMIT $8
+LIMIT $9

--- a/pointercrate-demonlist/sql/paginate_players_by_id.sql
+++ b/pointercrate-demonlist/sql/paginate_players_by_id.sql
@@ -1,7 +1,7 @@
 SELECT id, players.name::TEXT, banned, nationalities.nation::TEXT, iso_country_code::TEXT, subdivision::TEXT AS iso_code, subdivisions.name AS subdivision_name, players.score
 FROM players
 LEFT OUTER JOIN nationalities ON nationality = iso_country_code
-LEFT JOIN subdivisions ON iso_code = subdivision AND subdivisions.nation = nationality
+LEFT OUTER JOIN subdivisions ON iso_code = subdivision AND subdivisions.nation = nationality
 WHERE (id < $1 OR $1 IS NULL)
   AND (id > $2 OR $2 IS NULL)
   AND (players.name = $3::CITEXT OR $3 is NULL)

--- a/pointercrate-demonlist/src/demon/audit.rs
+++ b/pointercrate-demonlist/src/demon/audit.rs
@@ -77,7 +77,7 @@ pub async fn movement_log_for_demon(demon_id: i32, connection: &mut PgConnection
             all_moves.insert(
                 row.time,
                 NamedId {
-                    id: row.id,
+                    id: row.id.expect("idk lol"),
                     name: row.name,
                 },
             );
@@ -118,7 +118,7 @@ pub async fn movement_log_for_demon(demon_id: i32, connection: &mut PgConnection
                         continue;
                     }
 
-                    let moved = all_moves.get(&time);
+                    let moved = all_moves.get(&Some(time));
 
                     match moved {
                         Some(id) if id.id == demon_id => movement_log.push(MovementLogEntry {

--- a/pointercrate-demonlist/src/demon/audit.rs
+++ b/pointercrate-demonlist/src/demon/audit.rs
@@ -77,7 +77,7 @@ pub async fn movement_log_for_demon(demon_id: i32, connection: &mut PgConnection
             all_moves.insert(
                 row.time,
                 NamedId {
-                    id: row.id.expect("idk lol"),
+                    id: row.id,
                     name: row.name,
                 },
             );
@@ -118,7 +118,7 @@ pub async fn movement_log_for_demon(demon_id: i32, connection: &mut PgConnection
                         continue;
                     }
 
-                    let moved = all_moves.get(&Some(time));
+                    let moved = all_moves.get(&time);
 
                     match moved {
                         Some(id) if id.id == demon_id => movement_log.push(MovementLogEntry {

--- a/pointercrate-test/tests/demonlist/player/mod.rs
+++ b/pointercrate-test/tests/demonlist/player/mod.rs
@@ -1,10 +1,12 @@
+use pointercrate_test::TestClient;
 use pointercrate_demonlist::{
     nationality::{Nationality, Subdivision},
     player::{DatabasePlayer, FullPlayer, Player},
     LIST_HELPER,
+    LIST_MODERATOR
 };
 use rocket::http::Status;
-use sqlx::{PgConnection, Pool, Postgres};
+use sqlx::{pool::PoolConnection, PgConnection, Pool, Postgres};
 
 mod score;
 
@@ -213,4 +215,68 @@ async fn test_me(pool: Pool<Postgres>) {
             .await,
         player
     );
+}
+
+#[sqlx::test(migrations = "../migrations")]
+async fn test_players_pagination(pool: Pool<Postgres>) {
+    let (client, mut connection) = pointercrate_test::demonlist::setup_rocket(pool).await;
+    let moderator = pointercrate_test::user::system_user_with_perms(LIST_MODERATOR, &mut *connection).await;
+
+    // create players
+    let player1 = DatabasePlayer::by_name_or_create("stardust19701", &mut *connection).await.unwrap(); // no nationality, no subdivision
+    let player2 = DatabasePlayer::by_name_or_create("stardust19702", &mut *connection).await.unwrap(); // has nationality, no subdivision
+    let player3 = DatabasePlayer::by_name_or_create("stardust19703", &mut *connection).await.unwrap(); // has nationality, has subdivision
+
+    client.patch_player(player2.id, &moderator, serde_json::json!({"nationality": "GB"}))
+        .await
+        .execute()
+        .await;
+
+    client.patch_player(player3.id, &moderator, serde_json::json!({"nationality": "GB", "subdivision": "ENG"}))
+        .await
+        .execute()
+        .await;
+
+    // test if all players are returned by the endpoint (without filters)
+    let players: Vec<Player> = client
+        .get("/api/v1/players")
+        .expect_status(Status::Ok)
+        .get_result()
+        .await;
+
+    assert_eq!(players.len(), 3, "Not all players are listed");
+    
+    assert_eq!(players[0].nationality, None);
+    assert_eq!(players[1].nationality, Some(Nationality {
+        iso_country_code: "GB".into(),
+        nation: "United Kingdom".into(),
+        subdivision: None,
+    }));
+    assert_eq!(players[2].nationality, Some(Nationality {
+        iso_country_code: "GB".into(),
+        nation: "United Kingdom".into(),
+        subdivision: Some(Subdivision {
+            iso_code: "ENG".into(),
+            name: "England".into(),
+        }),
+    }));
+
+    // test subdivision filter
+    let filtered_players: Vec<Player> = client
+        .get("/api/v1/players?subdivision=ENG")
+        .expect_status(Status::Ok)
+        .get_result()
+        .await;
+
+    assert_eq!(filtered_players.len(), 1, "Subdivision filter did not return the correct number of players");
+
+    assert_eq!(filtered_players[0].base.id, player3.id);
+    assert_eq!(filtered_players[0].nationality, Some(Nationality {
+        iso_country_code: "GB".into(),
+        nation: "United Kingdom".into(),
+        subdivision: Some(Subdivision {
+            iso_code: "ENG".into(),
+            name: "England".into(),
+        }),
+    }));
 }

--- a/pointercrate-test/tests/demonlist/player/mod.rs
+++ b/pointercrate-test/tests/demonlist/player/mod.rs
@@ -6,7 +6,7 @@ use pointercrate_demonlist::{
     LIST_MODERATOR
 };
 use rocket::http::Status;
-use sqlx::{pool::PoolConnection, PgConnection, Pool, Postgres};
+use sqlx::{PgConnection, Pool, Postgres};
 
 mod score;
 
@@ -262,16 +262,42 @@ async fn test_players_pagination(pool: Pool<Postgres>) {
     }));
 
     // test subdivision filter
-    let filtered_players: Vec<Player> = client
+    let subdivision_filtered_players: Vec<Player> = client
         .get("/api/v1/players?subdivision=ENG")
         .expect_status(Status::Ok)
         .get_result()
         .await;
 
-    assert_eq!(filtered_players.len(), 1, "Subdivision filter did not return the correct number of players");
+    assert_eq!(subdivision_filtered_players.len(), 1, "Subdivision filter did not return the correct number of players");
 
-    assert_eq!(filtered_players[0].base.id, player3.id);
-    assert_eq!(filtered_players[0].nationality, Some(Nationality {
+    assert_eq!(subdivision_filtered_players[0].base.id, player3.id);
+    assert_eq!(subdivision_filtered_players[0].nationality, Some(Nationality {
+        iso_country_code: "GB".into(),
+        nation: "United Kingdom".into(),
+        subdivision: Some(Subdivision {
+            iso_code: "ENG".into(),
+            name: "England".into(),
+        }),
+    }));
+
+    // test nation filter
+    let nation_filtered_players: Vec<Player> = client
+        .get("/api/v1/players?nation=GB")
+        .expect_status(Status::Ok)
+        .get_result()
+        .await;
+
+    assert_eq!(nation_filtered_players.len(), 2, "Nation filter did not return the correct number of players");
+
+    assert_eq!(nation_filtered_players[0].base.id, player2.id);
+    assert_eq!(nation_filtered_players[1].base.id, player3.id);
+
+    assert_eq!(nation_filtered_players[0].nationality, Some(Nationality {
+        iso_country_code: "GB".into(),
+        nation: "United Kingdom".into(),
+        subdivision: None,
+    }));
+    assert_eq!(nation_filtered_players[1].nationality, Some(Nationality {
         iso_country_code: "GB".into(),
         nation: "United Kingdom".into(),
         subdivision: Some(Subdivision {


### PR DESCRIPTION
Adds support for a `subdivision` query parameter, this also resolves subdivisions always being null

There are subdivisions with the same `iso_code`, which is the reason for the additional condition
> `LEFT JOIN subdivisions ON iso_code = subdivision AND subdivisions.nation = nationality`

Resolves #213 

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
