### PR TITLE
List players with 0 points in stats viewer

### DIFF
--- a/migrations/20250323004031_list_scoreless_players.down.sql
+++ b/migrations/20250323004031_list_scoreless_players.down.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE VIEW ranked_players AS 
+    SELECT 
+        ROW_NUMBER() OVER(ORDER BY players.score DESC, id) AS index,
+        RANK() OVER(ORDER BY players.score DESC) AS rank,
+        id, name, players.score, subdivision,
+        nationalities.iso_country_code,
+        nationalities.nation,
+        nationalities.continent
+    FROM players
+    LEFT OUTER JOIN nationalities
+                 ON players.nationality = nationalities.iso_country_code
+    WHERE NOT players.banned AND players.score > 0.0;

--- a/migrations/20250323004031_list_scoreless_players.up.sql
+++ b/migrations/20250323004031_list_scoreless_players.up.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE VIEW ranked_players AS 
+    SELECT 
+        ROW_NUMBER() OVER(ORDER BY players.score DESC, id) AS index,
+        (CASE WHEN players.score = 0.0 THEN NULL
+        ELSE RANK() OVER(ORDER BY players.score DESC)
+        END) AS rank,
+        id, name, players.score, subdivision,
+        nationalities.iso_country_code,
+        nationalities.nation,
+        nationalities.continent
+    FROM players
+    LEFT OUTER JOIN nationalities
+                 ON players.nationality = nationalities.iso_country_code
+    WHERE NOT players.banned;

--- a/pointercrate-demonlist-pages/static/js/modules/statsviewer.js
+++ b/pointercrate-demonlist-pages/static/js/modules/statsviewer.js
@@ -153,7 +153,7 @@ export class StatsViewer extends FilteredPaginator {
     super.onReceive(response);
 
     // Using currentlySelected is O.K. here, as selection via clicking li-elements is the only possibility (well, not for the nation based one, but oh well)!
-    this._rank.innerText = this.currentlySelected.dataset.rank;
+    this._rank.innerText = this.currentlySelected.dataset.rank ?? "None";
     this._score.innerHTML =
       this.currentlySelected.getElementsByTagName("i")[0].innerHTML;
   }

--- a/pointercrate-demonlist-pages/static/js/statsviewer/individual.js
+++ b/pointercrate-demonlist-pages/static/js/statsviewer/individual.js
@@ -16,6 +16,7 @@ class IndividualStatsViewer extends StatsViewer {
       rankingEndpoint: "/api/v1/players/ranking/",
       entryGenerator: generateStatsViewerPlayer,
     });
+    this.updateQueryData("scoreless", true);
   }
 
   onReceive(response) {
@@ -198,9 +199,12 @@ function generateStatsViewerPlayer(player) {
 
   li.className = "white hover";
   li.dataset.id = player.id;
-  li.dataset.rank = player.rank;
+  
+  if (player.rank) {
+    li.dataset.rank = player.rank;
+    b.appendChild(document.createTextNode("#" + player.rank + " "));
+  }
 
-  b.appendChild(document.createTextNode("#" + player.rank + " "));
   i.appendChild(document.createTextNode(player.score.toFixed(2)));
 
   if (player.nationality) {

--- a/pointercrate-demonlist/sql/paginate_player_ranking.sql
+++ b/pointercrate-demonlist/sql/paginate_player_ranking.sql
@@ -6,5 +6,6 @@ WHERE (index < $1 OR $1 IS NULL)
   AND (nation = $4 OR iso_country_code = $4 OR (nation IS NULL AND $5) OR ($4 IS NULL AND NOT $5))
   AND (continent = CAST($6::TEXT AS continent) OR $6 IS NULL)
   AND (subdivision = $7 OR $7 IS NULL)
+  AND (score > 0.0 OR $8 = TRUE)
 ORDER BY rank {}, id
-LIMIT $8
+LIMIT $9

--- a/pointercrate-demonlist/src/player/paginate.rs
+++ b/pointercrate-demonlist/src/player/paginate.rs
@@ -128,6 +128,9 @@ pub struct RankingPagination {
 
     #[serde(default, deserialize_with = "non_nullable")]
     name_contains: Option<String>,
+
+    #[serde(default, deserialize_with = "non_nullable")]
+    scoreless: Option<bool>,
 }
 
 impl PaginationQuery for RankingPagination {
@@ -145,7 +148,7 @@ impl PaginationQuery for RankingPagination {
 
 #[derive(Debug, Serialize)]
 pub struct RankedPlayer {
-    rank: i64,
+    rank: Option<i64>,
     #[serde(skip)]
     index: i64,
     #[serde(flatten)]
@@ -174,6 +177,7 @@ impl Paginatable<RankingPagination> for RankedPlayer {
             .bind(query.nation == Some(None))
             .bind(query.continent.as_ref().map(|c| c.to_sql()))
             .bind(&query.subdivision)
+            .bind(query.scoreless)
             .bind(query.params.limit + 1)
             .fetch(connection);
 


### PR DESCRIPTION
Modified the `ranked_players` view to include scoreless players and give them a `null` rank
To include scoreless players in the response of `/players/ranking`, a `scoreless` query parameter must be provided and set to true (to not break anything which *may* rely on ranks not being null)

Resolves #132 

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
