### PR TITLE
Fix progress section in nation stats viewer

### DIFF
--- a/pointercrate-demonlist-pages/static/js/statsviewer/nation.js
+++ b/pointercrate-demonlist-pages/static/js/statsviewer/nation.js
@@ -39,7 +39,7 @@ class NationStatsViewer extends StatsViewer {
       record.players.forEach(players.add, players);
 
       if (record.progress !== 100) {
-        if (!nationData.verified.some((d) => d.id === record.id))
+        if (!nationData.verified.some((d) => d.demon.id === record.demon.id))
           progress.push(record);
       } else {
         beaten.push(record);


### PR DESCRIPTION
The progress section in the nation stats viewer never works because of a faulty condition

When checking if a non-100% record was already verified by someone else, it would *always* match `undefined === undefined` since `d` and `record` are structured like this

![image](https://github.com/user-attachments/assets/3dcb7c46-9a30-4df9-b032-033ce9c6af1e)

This is presumably introduced by #230 

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
