### PR TITLE
Small overview page QoL improvements

### DIFF
--- a/pointercrate-core-pages/static/css/ui.css
+++ b/pointercrate-core-pages/static/css/ui.css
@@ -493,6 +493,10 @@ p.error {
   .viewer {
     flex-wrap: wrap;
   }
+  
+  .no-mobile {
+    display: none
+  }
 }
 
 .stats-container {

--- a/pointercrate-demonlist-pages/src/overview.rs
+++ b/pointercrate-demonlist-pages/src/overview.rs
@@ -171,7 +171,7 @@ impl OverviewPage {
                         }
                      }
                     @if self.claimed_player.is_some() {
-                        div.flex.col style = "font-weight: bold; text-align: right" {
+                        div.flex.col.no-mobile style = "font-weight: bold; text-align: right" {
                             span style = "font-size: 300%" { (progress) "%" }
                             span style = "font-size: 0.8em"{ (progress_score) " points"}
                         }

--- a/pointercrate-demonlist-pages/src/overview.rs
+++ b/pointercrate-demonlist-pages/src/overview.rs
@@ -22,38 +22,6 @@ pub struct OverviewPage {
     pub claimed_player: Option<FullPlayer>
 }
 
-fn demon_panel(demon: &Demon, current_position: Option<i16>) -> Markup {
-    let video_link = demon.video.as_deref().unwrap_or("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
-    html! {
-         section.panel.fade style="overflow:hidden" {
-             div.flex style = "align-items: center" {
-                 a.thumb."ratio-16-9"."js-delay-css" href = (video_link) style = "position: relative" data-property = "background-image" data-property-value = {"url('" (demon.thumbnail) "')"} {}
-                 div style = "padding-left: 15px" {
-                     h2 style = "text-align: left; margin-bottom: 0px" {
-                         a href = {"/demonlist/permalink/" (demon.base.id) "/"} {
-                             "#" (demon.base.position) (PreEscaped(" &#8211; ")) (demon.base.name)
-                         }
-                     }
-                     h3 style = "text-align: left" {
-                         i {
-                             (demon.publisher.name)
-                         }
-                         @if let Some(current_position) = current_position {
-                             br;
-                             @if current_position > list_config::extended_list_size() {
-                                 "Currently Legacy"
-                             }
-                             @else {
-                                 "Currently #"(current_position)
-                             }
-                         }
-                     }
-                 }
-             }
-         }
-    }
-}
-
 impl From<OverviewPage> for PageFragment {
     fn from(page: OverviewPage) -> Self {
         PageFragment::new("Geometry Dash Demonlist", "The official pointercrate Demonlist!")
@@ -133,14 +101,14 @@ impl OverviewPage {
                         Tardis::Activated { demons, ..} => {
                             @for TimeShiftedDemon {current_demon, position_now} in demons {
                                 @if current_demon.base.position <= list_config::extended_list_size() {
-                                    (demon_panel(current_demon, Some(*position_now)))
+                                    (self.demon_panel(current_demon, Some(*position_now)))
                                 }
                             }
                         },
                         _ => {
                             @for demon in &self.demonlist {
                                 @if demon.base.position <= list_config::extended_list_size() {
-                                    (demon_panel(demon, None))
+                                    (self.demon_panel(demon, None))
                                 }
                             }
                         }
@@ -155,6 +123,38 @@ impl OverviewPage {
                     (super::discord_panel())
                 }
             }
+        }
+    }
+
+    fn demon_panel(&self, demon: &Demon, current_position: Option<i16>) -> Markup {
+        let video_link = demon.video.as_deref().unwrap_or("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+        html! {
+             section.panel.fade style="overflow:hidden" {
+                 div.flex style = "align-items: center" {
+                     a.thumb."ratio-16-9"."js-delay-css" href = (video_link) style = "position: relative" data-property = "background-image" data-property-value = {"url('" (demon.thumbnail) "')"} {}
+                     div style = "padding-left: 15px" {
+                         h2 style = "text-align: left; margin-bottom: 0px" {
+                             a href = {"/demonlist/permalink/" (demon.base.id) "/"} {
+                                 "#" (demon.base.position) (PreEscaped(" &#8211; ")) (demon.base.name)
+                             }
+                         }
+                         h3 style = "text-align: left" {
+                             i {
+                                 (demon.publisher.name)
+                             }
+                             @if let Some(current_position) = current_position {
+                                 br;
+                                 @if current_position > list_config::extended_list_size() {
+                                     "Currently Legacy"
+                                 }
+                                 @else {
+                                     "Currently #"(current_position)
+                                 }
+                             }
+                         }
+                     }
+                 }
+             }
         }
     }
 }

--- a/pointercrate-demonlist-pages/src/overview.rs
+++ b/pointercrate-demonlist-pages/src/overview.rs
@@ -139,8 +139,8 @@ impl OverviewPage {
                              }
                          }
                          h3 style = "text-align: left" {
-                             i {
-                                 (demon.publisher.name)
+                             span {
+                                 "published by " a.underdotted href = {"/demonlist/statsviewer?player="(demon.publisher.id)} {(demon.publisher.name)}
                              }
                              @if let Some(current_position) = current_position {
                                  br;

--- a/pointercrate-demonlist-pages/src/overview.rs
+++ b/pointercrate-demonlist-pages/src/overview.rs
@@ -128,6 +128,9 @@ impl OverviewPage {
 
     fn demon_panel(&self, demon: &Demon, current_position: Option<i16>) -> Markup {
         let video_link = demon.video.as_deref().unwrap_or("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+        let total_score = format!("{:.2}", demon.score(100));
+        let minimal_score = format!("{:.2}", demon.score(demon.requirement));
+
         html! {
              section.panel.fade style="overflow:hidden" {
                  div.flex style = "align-items: center" {
@@ -139,19 +142,21 @@ impl OverviewPage {
                              }
                          }
                          h3 style = "text-align: left" {
-                             span {
-                                 "published by " a.underdotted href = {"/demonlist/statsviewer?player="(demon.publisher.id)} {(demon.publisher.name)}
-                             }
-                             @if let Some(current_position) = current_position {
-                                 br;
+                             "published by " a.underdotted href = {"/demonlist/statsviewer?player="(demon.publisher.id)} {(demon.publisher.name)}
+                         }
+                        div style="text-align: left; font-size: 0.8em" {
+                            @if let Some(current_position) = current_position {
                                  @if current_position > list_config::extended_list_size() {
                                      "Currently Legacy"
                                  }
                                  @else {
                                      "Currently #"(current_position)
                                  }
-                             }
-                         }
+                            }
+                            @else {
+                                (minimal_score) " (" (demon.requirement) "%) — " (total_score) " (100%) points"
+                            }
+                        }
                      }
                  }
              }

--- a/pointercrate-demonlist-pages/src/overview.rs
+++ b/pointercrate-demonlist-pages/src/overview.rs
@@ -128,7 +128,17 @@ impl OverviewPage {
 
     fn demon_panel(&self, demon: &Demon, current_position: Option<i16>) -> Markup {
         let video_link = demon.video.as_deref().unwrap_or("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+
+        let progress = self.claimed_player.as_ref().and_then(|player| {
+            if player.verified.iter().any(|d| d.id == demon.base.id) {
+                Some(100)
+            }  else {
+                player.records.iter().find(|r| r.demon.id == demon.base.id).map(|r| r.progress)
+            }
+        }).unwrap_or_default();
+
         let total_score = format!("{:.2}", demon.score(100));
+        let progress_score = format!("{:.2}", demon.score(progress));
         let minimal_score = format!("{:.2}", demon.score(demon.requirement));
 
         html! {
@@ -158,6 +168,12 @@ impl OverviewPage {
                             }
                         }
                      }
+                    @if self.claimed_player.is_some() {
+                        div.flex.col style = "font-weight: bold; text-align: right" {
+                            span style = "font-size: 300%" { (progress) "%" }
+                            span style = "font-size: 0.8em"{ (progress_score) " points"}
+                        }
+                    }
                  }
              }
         }

--- a/pointercrate-demonlist-pages/src/overview.rs
+++ b/pointercrate-demonlist-pages/src/overview.rs
@@ -141,8 +141,10 @@ impl OverviewPage {
         let progress_score = format!("{:.2}", demon.score(progress));
         let minimal_score = format!("{:.2}", demon.score(demon.requirement));
 
+        let bg_color = if progress == 100 { "#ddffdd;"} else {"white"};
+        
         html! {
-             section.panel.fade style="overflow:hidden" {
+             section.panel.fade style={"overflow:hidden; background:"(bg_color)} {
                  div.flex style = "align-items: center" {
                      a.thumb."ratio-16-9"."js-delay-css" href = (video_link) style = "position: relative" data-property = "background-image" data-property-value = {"url('" (demon.thumbnail) "')"} {}
                      div style = "padding-left: 15px" {

--- a/pointercrate-demonlist-pages/src/overview.rs
+++ b/pointercrate-demonlist-pages/src/overview.rs
@@ -12,12 +12,14 @@ use pointercrate_demonlist::{
     config as list_config,
     demon::{Demon, TimeShiftedDemon},
 };
+use pointercrate_demonlist::player::FullPlayer;
 
 pub struct OverviewPage {
     pub team: Team,
     pub demonlist: Vec<Demon>,
     pub time_machine: Tardis,
     pub submitter_initially_visible: bool,
+    pub claimed_player: Option<FullPlayer>
 }
 
 fn demon_panel(demon: &Demon, current_position: Option<i16>) -> Markup {

--- a/pointercrate-demonlist-pages/static/css/demonlist.css
+++ b/pointercrate-demonlist-pages/static/css/demonlist.css
@@ -67,16 +67,6 @@ tr:nth-child(even) {
   font-weight: normal;
 }
 
-#outofboundsad {
-  width: 200px;
-}
-
-@media (max-width: 1359px) {
-  #outofboundsad {
-    display: none;
-  }
-}
-
 @media (max-width: 1071px) {
   #rules,
   #discord {

--- a/pointercrate-demonlist/src/demon/mod.rs
+++ b/pointercrate-demonlist/src/demon/mod.rs
@@ -218,6 +218,10 @@ impl Demon {
     }
 
     pub fn score(&self, progress: i16) -> f64 {
+        if progress < self.requirement {
+            return 0.0
+        }
+        
         let position = self.base.position;
 
         let beaten_score = match position {


### PR DESCRIPTION
With player claims being mostly in place, and google oauth at least saving us from "I forgot my password", we can start implementing some much requested features traditionally home to the demonlist+ extension into pointercrate itself. For starters, this PR implements the "progress on overview" stuff, based on player claims (the claim does not need to be verified for this).

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
