### PR TITLE
Fix: remove raw footage VOD info from record submitter

### DIFF
--- a/pointercrate-demonlist-pages/static/ftl/en-us/submitter.ftl
+++ b/pointercrate-demonlist-pages/static/ftl/en-us/submitter.ftl
@@ -47,7 +47,7 @@ record-submission = Record Submission
     .video-validator-typemismatch = Please enter a valid URL
 
     .raw-footage = Raw footage
-    .raw-footage-info-a = The unedited and untrimmed video for this completion, uploaded to a non-compressing (e.g. not YouTube) file-sharing service such as google drive.
+    .raw-footage-info-a = The unedited and untrimmed video for this completion, uploaded to a non-compressing (e.g. not YouTube) file-sharing service such as google drive. Note: Players can be given a one-time exception to use a stream VOD as raw footage.
     .raw-footage-info-b = Any personal information possibly contained within raw footage (e.g. names, sensitive conversations) will be kept strictly confidential and will not be shared outside of the demonlist team. Conversely, you acknowledge that you might inadvertently share such information by providing raw footage. You have the right to request deletion of your record note by contacting a list administrator.
     .raw-footage-note = This is required for every record submitted to the list!
 


### PR DESCRIPTION
Seems like VODs as raw footage aren't allowed anymore ([Discord message](https://discord.com/channels/395654171422097420/395692399919366147/1373005359110950994)).

"After May 22nd 2025 00:00 EST, livestreams will no longer be accepted as valid form of raw footage for record submissions."
"From that date forward, only unedited recordings captured through recording software (e.g., OBS, Shadowplay / NVIDIA APP, AMD Relive), and liveplays will be accepted on Pointercrate."

Let me know if I missed any other references to this :)

[Guidelines PR](https://github.com/stadust/demonlist-guidelines/pull/12)

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
