### PR TITLE
Fix YouTube embeds displaying Error 153 on demon pages

### DIFF
--- a/pointercrate-core-pages/src/lib.rs
+++ b/pointercrate-core-pages/src/lib.rs
@@ -36,7 +36,7 @@ impl PageConfiguration {
             head: Head::new(default_head_html)
                 .meta("og:site_name", site_name)
                 .meta("og:type", "website")
-                .meta("referrer", "no-referrer")
+                .meta("referrer", "strict-origin-when-cross-origin")
                 .meta("viewport", "initial-scale=1, maximum-scale=1")
                 .script("https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js")
                 .script("https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js")


### PR DESCRIPTION
fixes youtube embeds on demon pages displaying an "Error 153 Video player configuration error" by changing the value of the "referrer" meta tag in the `<head>` to ensure that a `Referer` header will be sent through the embedded player

i just went with `strict-origin-when-cross-origin` since it felt like the best option (https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/referrer)

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
