### PR TITLE
Fairing for internally normalizing request URIs

### DIFF
--- a/pointercrate-core-api/src/lib.rs
+++ b/pointercrate-core-api/src/lib.rs
@@ -2,6 +2,7 @@ pub mod error;
 pub mod etag;
 pub mod localization;
 pub mod maintenance;
+pub mod normalize_uri;
 pub mod pagination;
 pub mod preferences;
 pub mod query;

--- a/pointercrate-core-api/src/normalize_uri.rs
+++ b/pointercrate-core-api/src/normalize_uri.rs
@@ -1,0 +1,66 @@
+use std::sync::OnceLock;
+
+use rocket::{
+    fairing::{Fairing, Info, Kind},
+    Data, Orbit, Request, Rocket, Route,
+};
+
+// heavily inspired by rocket's `rocket::fairing::AdHoc::uri_normalizer()` implementation
+// only difference is that this applies a trailing slash internally as opposed to omitting it
+// https://api.rocket.rs/master/src/rocket/fairing/ad_hoc.rs#315
+pub fn uri_normalizer() -> impl Fairing {
+    #[derive(Default)]
+    struct Normalizer {
+        routes: OnceLock<Vec<Route>>,
+    }
+
+    impl Normalizer {
+        fn routes(&self, rocket: &Rocket<Orbit>) -> &[Route] {
+            // gather all defined routes which have a trailing slash
+            self.routes.get_or_init(|| {
+                rocket
+                    .routes()
+                    .filter(|r| r.uri.has_trailing_slash() || r.uri.path() == "/")
+                    .cloned()
+                    .collect()
+            })
+        }
+    }
+
+    #[rocket::async_trait]
+    impl Fairing for Normalizer {
+        fn info(&self) -> Info {
+            Info {
+                name: "URI Normalizer",
+                kind: Kind::Liftoff | Kind::Request,
+            }
+        }
+
+        async fn on_liftoff(&self, rocket: &Rocket<Orbit>) {
+            let _ = self.routes(rocket);
+        }
+
+        async fn on_request(&self, request: &mut Request<'_>, _: &mut Data<'_>) {
+            if request.uri().has_trailing_slash() {
+                return;
+            }
+
+            if let Some(normalized) = request.uri().map_path(|p| format!("{}/", p)) {
+                // check if the normalized uri (the request uri with a trailing slash) matches one of our defined routes
+                let mut normalized_req = request.clone();
+                normalized_req.set_uri(normalized.clone());
+
+                if self.routes(request.rocket()).iter().any(|r| {
+                    // we need to leverage rocket's route matching otherwise this will suck
+                    r.matches(&normalized_req)
+                }) {
+                    // the request doesn't have a trailing slash AND it's trying to reach one of our defined routes
+                    // so just point it to our defined route
+                    request.set_uri(normalized);
+                }
+            }
+        }
+    }
+
+    Normalizer::default()
+}

--- a/pointercrate-example/src/main.rs
+++ b/pointercrate-example/src/main.rs
@@ -2,6 +2,7 @@ use maud::html;
 use pointercrate_core::localization::LocalesLoader;
 use pointercrate_core::pool::PointercratePool;
 use pointercrate_core::{error::CoreError, localization::tr};
+use pointercrate_core_api::normalize_uri::uri_normalizer;
 use pointercrate_core_api::{error::ErrorResponder, maintenance::MaintenanceFairing, preferences::PreferenceManager};
 use pointercrate_core_macros::localized_catcher;
 use pointercrate_core_pages::{
@@ -178,6 +179,7 @@ async fn rocket() -> _ {
     // static files.
 
     rocket
+        .attach(uri_normalizer())
         .mount("/static/core", FileServer::new("pointercrate-core-pages/static"))
         .mount("/static/demonlist", FileServer::new("pointercrate-demonlist-pages/static"))
         .mount("/static/user", FileServer::new("pointercrate-user-pages/static"))


### PR DESCRIPTION
adds a fairing which appends a trailing slash (if needed) to incoming requests, but only for route handlers whose URIs have a trailing slash (so if the route is `#[rocket::get("/foo")]` the fairing won't do anything)
this fairing will **not** add a trailing slash if the request is attempting to fetch static files, since it only modifies requests which are trying to reach one of our route handlers

this eliminates the need for some server config and also keeps behavior consistent between both variants, with and without a trailing slash

i found this useful for my local environment so i figured i'll open a pr 🙃 there are a handful of things that point to uris without the trailing slash so this fixes the nuisance

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
