### PR TITLE
feat: add redirection support for demonlist via /demonlist/levelid/<level_id>

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ If everything is set up correctly, you should see `rocket`'s development server 
    >> (stats_viewer) GET /demonlist/statsviewer
    >> (nation_stats_viewer) GET /demonlist/statsviewer/nations
    >> (demon_permalink) GET /demonlist/permalink/<demon_id>
+   >> (demon_levelid) GET /demonlist/levelid/<level_id>
    >> (heatmap_css) GET /demonlist/statsviewer/heatmap.css
    >> (FileServer: pointercrate-core-pages/static) GET /static/core/<path..> [10]
    >> (FileServer: pointercrate-user-pages/static) GET /static/user/<path..> [10]

--- a/pointercrate-demonlist-api/src/lib.rs
+++ b/pointercrate-demonlist-api/src/lib.rs
@@ -97,6 +97,7 @@ pub fn setup(rocket: Rocket<Build>) -> Rocket<Build> {
                 pages::nation_stats_viewer,
                 pages::demon_page,
                 pages::demon_permalink,
+                pages::demon_levelid,
                 pages::heatmap_css
             ],
         )

--- a/pointercrate-demonlist-api/src/pages.rs
+++ b/pointercrate-demonlist-api/src/pages.rs
@@ -93,6 +93,15 @@ pub async fn demon_permalink(demon_id: i32, pool: &State<PointercratePool>) -> R
     Ok(Redirect::to(rocket::uri!("/demonlist", demon_page(position))))
 }
 
+#[rocket::get("/levelid/<level_id>/")]
+pub async fn demon_levelid(level_id: i32, pool: &State<PointercratePool>) -> Result<Redirect> {
+    let mut connection = pool.connection().await?;
+
+    let position = MinimalDemon::by_level_id(level_id, &mut connection).await?.position;
+
+    Ok(Redirect::to(rocket::uri!("/demonlist", demon_page(position))))
+}
+
 #[localized]
 #[rocket::get("/<position>/")]
 pub async fn demon_page(position: i16, pool: &State<PointercratePool>, gd: &State<GeometryDashConnector>) -> Result<Page> {

--- a/pointercrate-demonlist/src/demon/get.rs
+++ b/pointercrate-demonlist/src/demon/get.rs
@@ -20,6 +20,16 @@ impl MinimalDemon {
             })
     }
 
+    pub async fn by_level_id(id: i32, connection: &mut PgConnection) -> Result<MinimalDemon> {
+        sqlx::query_as!(MinimalDemon, r#"SELECT id, name, position FROM demons WHERE level_id = $1"#, i64::from(id))
+            .fetch_one(connection)
+            .await
+            .map_err(|err| match err {
+                Error::RowNotFound => DemonlistError::DemonNotFoundLevelID { level_id: id },
+                _ => err.into(),
+            })
+    }
+
     pub async fn by_name(name: &str, connection: &mut PgConnection) -> Result<MinimalDemon> {
         let mut stream = sqlx::query!(r#"SELECT id, name, position FROM demons WHERE name = $1"#, name.to_string()).fetch(connection);
 

--- a/pointercrate-demonlist/src/error.rs
+++ b/pointercrate-demonlist/src/error.rs
@@ -78,6 +78,10 @@ pub enum DemonlistError {
         demon_id: i32,
     },
 
+    DemonNotFoundLevelID {
+        level_id: i32,
+    },
+
     DemonNotFoundName {
         demon_name: String,
     },
@@ -226,6 +230,7 @@ impl PointercrateError for DemonlistError {
             PlayerNotFound { .. } => 40401,
             PlayerNotFoundName { .. } => 40401,
             DemonNotFound { .. } => 40401,
+            DemonNotFoundLevelID { .. } => 40401,
             DemonNotFoundName { .. } => 40401,
             DemonNotFoundPosition { .. } => 40401,
             RecordNotFound { .. } => 40401,
@@ -283,6 +288,7 @@ impl Display for DemonlistError {
                 DemonlistError::PlayerNotFoundName { player_name } =>
                     trp!("error-demonlist-playernotfoundname", "player-name" = player_name),
                 DemonlistError::DemonNotFound { demon_id } => trp!("error-demonlist-demonnotfound", "demon-id" = demon_id),
+                DemonlistError::DemonNotFoundLevelID { level_id } => trp!("error-demonlist-demonnotfoundlevelid", "level-id" = level_id),
                 DemonlistError::DemonNotFoundName { demon_name } => trp!("error-demonlist-demonnotfoundname", "demon-name" = demon_name),
                 DemonlistError::DemonNotFoundPosition { demon_position } =>
                     trp!("error-demonlist-demonnotfoundposition", "demon-position" = demon_position),


### PR DESCRIPTION
Adding a redirection route for `/demonlist/levelid/<level_id>`. This behaves identically to the current `/demonlist/permalink/<demon_id>` behavior (redirecting to the current position).

It would improve developer and user experience, making it easier to share or link to specific demons programmatically.

### Why this is needed:
1. **Fixes Broken Links due to Rank Fluctuations:** Currently, referencing a demon by its list position (e.g., `/demonlist/1/`) is unreliable because the leaderboard is dynamic. When new top demons are added or placements shift, the old URL points to a completely different level.
2. **True Immutable Permalink:** In contrast to internal `demon_id`, Geometry Dash's `level_id` is an immutable, universally recognized identifier within the community. Utilizing it as a redirection route guarantees a permanent, unbreakable link to a specific demon, regardless of future rank variations.

### Example:
* **Request:** `https://pointercrate.com/demonlist/levelid/127323087` (127323087 is Society's level id)
* **Behavior:** Redirects to the current demon page (e.g., `https://pointercrate.com/demonlist/1/`)

It resolves #354 

## License Acceptance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.